### PR TITLE
Add github action workflows for building production docker images

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -1,0 +1,25 @@
+name: Docker Build Main
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Clone latest repository
+      uses: actions/checkout@v2
+    - name: Build web container image and push to DockerHub
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: 'mlibrary/patron-account-unstable:${{ github.sha }},mlibrary/patron-account-unstable:latest'
+        file: Dockerfile.prod

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -1,0 +1,26 @@
+name: Docker Tag Latest Release
+
+on:
+  release:
+    types: [ released ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Clone latest repository
+      uses: actions/checkout@v2
+    - name: Tag latest release in DockerHub
+      run: |
+        docker pull mlibrary/patron-account-unstable:${{ github.sha }}
+        docker tag mlibrary/patron-account-unstable:${{ github.sha }} mlibrary/patron-account:${{ github.event.release.tag_name }}
+        docker tag mlibrary/patron-account-unstable:${{ github.sha }} mlibrary/patron-account:latest
+        docker push mlibrary/patron-account:${{ github.event.release.tag_name }}
+        docker push mlibrary/patron-account:latest

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,41 @@
+FROM ruby:2.7.2
+ARG UNAME=app
+ARG UID=1000
+ARG GID=1000
+
+LABEL maintainer="mrio@umich.edu"
+
+RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
+  apt-transport-https
+
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+
+RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
+  nodejs
+
+RUN gem install bundler:2.1.4
+
+RUN groupadd -g ${GID} -o ${UNAME}
+RUN useradd -m -d /app -u ${UID} -g ${GID} -o -s /bin/bash ${UNAME}
+RUN mkdir -p /gems && chown ${UID}:${GID} /gems
+
+USER $UNAME
+COPY --chown=${UID}:${GID} Gemfile* /app/
+
+ENV BUNDLE_PATH /gems
+
+#Actually a secret
+ENV ALMA_API_KEY 'YOUR_ALMA_API_KEY'
+
+#Not that much of a secret
+ENV ALMA_API_HOST 'https://api-na.hosted.exlibrisgroup.com'
+
+WORKDIR /app
+RUN bundle install
+
+COPY --chown=${UID}:${GID} . /app
+
+RUN npm install
+RUN npm run compile
+
+CMD ["bundle", "exec", "ruby", "my_account.rb", "-o", "0.0.0.0"]


### PR DESCRIPTION
I've copied the Dockerfile into Dockerfile.prod so that the development
environment doesn't have to be the same as the production environment
(allowing for automated tests etc. in development).

On all pushes/merges into the main branch, a docker image will be pushed
to mlibrary/patron-account-unstable.

On all version releases, a docker image will be pushed to
mlibrary/patron-account.