### PR TITLE
Improve semantics of the local page navigation relationship with the h1

### DIFF
--- a/css/_base.scss
+++ b/css/_base.scss
@@ -65,9 +65,12 @@ h1 {
   margin-bottom: var(--space-large);
 }
 
-h2 {
+h2,
+.h2 {
+  font-family: var(--font-base-family);
   font-size: var(--text-large);
   font-weight: var(--bold);
+  line-height: auto;
 }
 
 h3 {

--- a/css/_loans.scss
+++ b/css/_loans.scss
@@ -16,3 +16,17 @@
     width: 40%;
   }
 }
+
+.shelf-navigation-container {
+  display: flex;
+  flex-direction: column;
+
+  .shelf-heading {
+    margin-top: var(--space-xx-large);
+    order: 2;
+  }
+
+  .local-navigation {
+    order: 1;
+  }
+}

--- a/css/_shelf-navigation.scss
+++ b/css/_shelf-navigation.scss
@@ -1,10 +1,8 @@
-.local-navigation {
-  ul {
-    list-style: none;
-    margin: 0;
+.shelf-navigation-list {
+  list-style: none;
+  margin: 0;
 
-    border-bottom: solid 1px var(--color-neutral-100);
-  }
+  border-bottom: solid 1px var(--color-neutral-100);
 
   li {
     display: inline-block;

--- a/css/_shelf-navigation.scss
+++ b/css/_shelf-navigation.scss
@@ -1,7 +1,6 @@
 .shelf-navigation-list {
   list-style: none;
   margin: 0;
-
   border-bottom: solid 1px var(--color-neutral-100);
 
   li {

--- a/css/index.scss
+++ b/css/index.scss
@@ -1,4 +1,4 @@
 @import "defaults.scss", "base.scss", "utilities.scss", "focus.scss",
-  "site-navigation.scss", "site-footer.scss", "overview-cards.scss",
+  U "shelf-navigation.scss", "site-footer.scss", "overview-cards.scss",
   "local-navigation.scss", "loans.scss", "form.scss", "buttons.scss",
   "pagination.scss", "messages", "text-notifications", "tags";

--- a/css/index.scss
+++ b/css/index.scss
@@ -1,4 +1,4 @@
 @import "defaults.scss", "base.scss", "utilities.scss", "focus.scss",
-  U "shelf-navigation.scss", "site-footer.scss", "overview-cards.scss",
+  "shelf-navigation.scss", "site-footer.scss", "overview-cards.scss",
   "local-navigation.scss", "loans.scss", "form.scss", "buttons.scss",
   "pagination.scss", "messages", "text-notifications", "tags";

--- a/css/index.scss
+++ b/css/index.scss
@@ -1,4 +1,4 @@
-@import "defaults.scss", "base.scss", "utilities.scss", "focus.scss",
-  "shelf-navigation.scss", "site-footer.scss", "overview-cards.scss",
-  "local-navigation.scss", "loans.scss", "form.scss", "buttons.scss",
-  "pagination.scss", "messages", "text-notifications", "tags";
+@import "defaults", "base", "utilities", "focus", "site-navigation",
+  "shelf-navigation", "site-footer", "overview-cards", "loans", "form",
+  "buttons", "pagination", "messages", "text-notifications", "tags";
+  

--- a/public/index.css
+++ b/public/index.css
@@ -241,9 +241,12 @@ h1 {
   line-height: var(--line-height-page-heading);
   margin-bottom: var(--space-large); }
 
-h2 {
+h2,
+.h2 {
+  font-family: var(--font-base-family);
   font-size: var(--text-large);
-  font-weight: var(--bold); }
+  font-weight: var(--bold);
+  line-height: auto; }
 
 h3 {
   font-size: var(--text-medium);
@@ -476,6 +479,15 @@ table {
     padding-right: var(--space-x-large); }
   .loans-empty-state-container img {
     width: 40%; }
+
+.shelf-navigation-container {
+  display: flex;
+  flex-direction: column; }
+  .shelf-navigation-container .shelf-heading {
+    margin-top: var(--space-xx-large);
+    order: 2; }
+  .shelf-navigation-container .local-navigation {
+    order: 1; }
 
 input[type="text"] {
   font-size: 1rem;

--- a/public/index.css
+++ b/public/index.css
@@ -442,32 +442,28 @@ table {
 .overview-card-description {
   color: var(--color-neutral-300); }
 
-.local-navigation ul {
+.shelf-navigation-list {
   list-style: none;
   margin: 0;
   border-bottom: solid 1px var(--color-neutral-100); }
-
-.local-navigation li {
-  display: inline-block;
-  margin-bottom: 0; }
-
-.local-navigation li:not(:last-of-type) {
-  padding-right: var(--space-large); }
-
-.local-navigation a {
-  display: inline-block;
-  padding: var(--space-medium) 0;
-  margin-bottom: -1px;
-  text-decoration: none;
-  color: var(--color-neutral-400);
-  font-weight: 600; }
-  .local-navigation a:not(.active):hover {
-    text-decoration: underline;
-    text-decoration-thickness: 2px; }
-
-.local-navigation a.active {
-  color: var(--color-teal-400);
-  border-bottom: 4px solid var(--color-teal-400); }
+  .shelf-navigation-list li {
+    display: inline-block;
+    margin-bottom: 0; }
+  .shelf-navigation-list li:not(:last-of-type) {
+    padding-right: var(--space-large); }
+  .shelf-navigation-list a {
+    display: inline-block;
+    padding: var(--space-medium) 0;
+    margin-bottom: -1px;
+    text-decoration: none;
+    color: var(--color-neutral-400);
+    font-weight: 600; }
+    .shelf-navigation-list a:not(.active):hover {
+      text-decoration: underline;
+      text-decoration-thickness: 2px; }
+  .shelf-navigation-list a.active {
+    color: var(--color-teal-400);
+    border-bottom: 4px solid var(--color-teal-400); }
 
 .loans-empty-state-container {
   display: flex;

--- a/public/index.css
+++ b/public/index.css
@@ -382,6 +382,29 @@ table {
       color: var(--color-teal-400);
       font-weight: var(--semibold); }
 
+.shelf-navigation-list {
+  list-style: none;
+  margin: 0;
+  border-bottom: solid 1px var(--color-neutral-100); }
+  .shelf-navigation-list li {
+    display: inline-block;
+    margin-bottom: 0; }
+  .shelf-navigation-list li:not(:last-of-type) {
+    padding-right: var(--space-large); }
+  .shelf-navigation-list a {
+    display: inline-block;
+    padding: var(--space-medium) 0;
+    margin-bottom: -1px;
+    text-decoration: none;
+    color: var(--color-neutral-400);
+    font-weight: 600; }
+    .shelf-navigation-list a:not(.active):hover {
+      text-decoration: underline;
+      text-decoration-thickness: 2px; }
+  .shelf-navigation-list a.active {
+    color: var(--color-teal-400);
+    border-bottom: 4px solid var(--color-teal-400); }
+
 .site-footer {
   margin-top: var(--space-xxx-large); }
 
@@ -441,29 +464,6 @@ table {
 
 .overview-card-description {
   color: var(--color-neutral-300); }
-
-.shelf-navigation-list {
-  list-style: none;
-  margin: 0;
-  border-bottom: solid 1px var(--color-neutral-100); }
-  .shelf-navigation-list li {
-    display: inline-block;
-    margin-bottom: 0; }
-  .shelf-navigation-list li:not(:last-of-type) {
-    padding-right: var(--space-large); }
-  .shelf-navigation-list a {
-    display: inline-block;
-    padding: var(--space-medium) 0;
-    margin-bottom: -1px;
-    text-decoration: none;
-    color: var(--color-neutral-400);
-    font-weight: 600; }
-    .shelf-navigation-list a:not(.active):hover {
-      text-decoration: underline;
-      text-decoration-thickness: 2px; }
-  .shelf-navigation-list a.active {
-    color: var(--color-teal-400);
-    border-bottom: 4px solid var(--color-teal-400); }
 
 .loans-empty-state-container {
   display: flex;

--- a/views/shelf.erb
+++ b/views/shelf.erb
@@ -1,6 +1,6 @@
 <h1 aria-hidden="true">Shelf</h1>
 
-<nav aria-labeledby="shelf-heading" class="shelf-navigation-container">
+<nav aria-labelledby="shelf-heading" class="shelf-navigation-container">
   <h1 class="h2 shelf-heading" id="shelf-heading"><span class="visually-hidden">Shelf: </span>Current loans</h1>
 
   <%= erb :shelf_navigation %>

--- a/views/shelf.erb
+++ b/views/shelf.erb
@@ -1,14 +1,16 @@
-<h1>Shelf</h1>
+<h1 aria-hidden="true">Shelf</h1>
 
-<%= erb :shelf_navigation %>
+<nav aria-labeledby="shelf-heading" class="shelf-navigation-container">
+  <h1 class="h2 shelf-heading" id="shelf-heading"><span class="visually-hidden">Shelf: </span>Current loans</h1>
+
+  <%= erb :shelf_navigation %>
+</nav>
 
 <% if loans.count == 0 %>
 
 <%= erb :loans_empty_state %>
 
 <% elsif %>
-
-<h2>Current loans</h2>
 
 <!--
 

--- a/views/shelf_navigation.erb
+++ b/views/shelf_navigation.erb
@@ -13,14 +13,13 @@
   },
 ] %>
 
-<nav aria-label="Shelf" class="local-navigation">
-  <ul>
-     <% pages.each do |page| %>
-        <li>
-          <a href="<%=page[:to]%>" class="<%= page[:to] == request.path_info ? 'active': '' %>">
-            <%=page[:label]%>
-          </a>
-        </li>
-      <% end %>
-  </ul>
-</nav>
+
+<ul class="shelf-navigation-list">
+    <% pages.each do |page| %>
+      <li>
+        <a href="<%=page[:to]%>" class="<%= page[:to] == request.path_info ? 'active': '' %>" >
+          <%=page[:label]%>
+        </a>
+      </li>
+    <% end %>
+</ul>


### PR DESCRIPTION
## What's up?

This change makes the DOM order [1] page heading, then [2] page navigation (eg shelf areas).

Where before it was `<h1>`, `<nav>`, `<h2>`, and the `<h2>` was the unique page name, which is an a11y issue.

The intention is for the semantics to match the design intent, so the experience is universal. Which is, [1] understand and orient to the page by the h1, then [2] Understand navigation and what shelf area is active.

Browser inspect preview:

![Screen Shot 2021-02-02 at 2 44 36 PM](https://user-images.githubusercontent.com/1678665/106653758-3d54c500-6565-11eb-9c29-af95e3d63c68.png)
