### PR TITLE
Document delivery

### DIFF
--- a/models/document_delivery.rb
+++ b/models/document_delivery.rb
@@ -1,0 +1,34 @@
+class DocumentDelivery
+  def initialize(parsed_response:)
+    @parsed_response = parsed_response
+    @deliveries = parsed_response.filter_map { |delivery| DocumentDeliveryItem.new(delivery) if delivery["RequestType"] == "Loan" && delivery["TransactionStatus"] != "Request Finished" }
+  end
+
+  def count
+    @deliveries.length
+  end
+
+  def each(&block)
+    @deliveries.each do |delivery|
+      block.call(delivery)
+    end
+  end
+
+  def self.for(uniqname:, client: ILLiadClient.new)
+    url = "/Transaction/UserRequests/#{uniqname}" 
+    response = client.get(url)
+    if response.code == 200
+      DocumentDelivery.new(parsed_response: response.parsed_response)
+    else
+      #Error!
+    end
+  end
+end
+
+class DocumentDeliveryItem < InterlibraryLoanItem
+  def initialize(parsed_response)
+    super
+    @title = @parsed_response["LoanTitle"]
+    @author = @parsed_response["LoanAuthor"]
+  end
+end

--- a/models/document_delivery.rb
+++ b/models/document_delivery.rb
@@ -1,17 +1,7 @@
-class DocumentDelivery
+class DocumentDelivery < Items
   def initialize(parsed_response:)
     @parsed_response = parsed_response
-    @deliveries = parsed_response.filter_map { |delivery| DocumentDeliveryItem.new(delivery) if delivery["RequestType"] == "Loan" && delivery["TransactionStatus"] != "Request Finished" }
-  end
-
-  def count
-    @deliveries.length
-  end
-
-  def each(&block)
-    @deliveries.each do |delivery|
-      block.call(delivery)
-    end
+    @items = parsed_response.filter_map { |item| DocumentDeliveryItem.new(item) if item["RequestType"] == "Loan" && item["TransactionStatus"] != "Request Finished" }
   end
 
   def self.for(uniqname:, client: ILLiadClient.new)

--- a/models/document_delivery.rb
+++ b/models/document_delivery.rb
@@ -1,6 +1,6 @@
 class DocumentDelivery < Items
   def initialize(parsed_response:)
-    @parsed_response = parsed_response
+    super
     @items = parsed_response.filter_map { |item| DocumentDeliveryItem.new(item) if item["RequestType"] == "Loan" && item["TransactionStatus"] != "Request Finished" }
   end
 

--- a/models/interlibrary_loan_requests.rb
+++ b/models/interlibrary_loan_requests.rb
@@ -26,10 +26,4 @@ class InterlibraryLoanRequests
 end
 
 class InterlibraryLoanRequest < InterlibraryLoanItem
-  def request_date
-    @parsed_response["CreationDate"] ? DateTime.patron_format(@parsed_response["CreationDate"]) : ''
-  end
-  def expiration_date
-    @parsed_response["DueDate"] ? DateTime.patron_format(@parsed_response["DueDate"]) : ''
-  end
 end

--- a/models/interlibrary_loan_requests.rb
+++ b/models/interlibrary_loan_requests.rb
@@ -1,17 +1,7 @@
-class InterlibraryLoanRequests
+class InterlibraryLoanRequests < Items
   def initialize(parsed_response:)
-    @parsed_response = parsed_response
-    @requests = parsed_response.filter_map { |request| InterlibraryLoanRequest.new(request) if request["RequestType"] != "Loan" && request["TransactionStatus"] != "Request Finished" }
-  end
-
-  def count
-    @requests.length
-  end
-
-  def each(&block)
-    @requests.each do |request|
-      block.call(request)
-    end
+    super
+    @items = parsed_response.filter_map { |item| InterlibraryLoanRequest.new(item) if item["RequestType"] != "Loan" && item["TransactionStatus"] != "Request Finished" }
   end
 
   def self.for(uniqname:, client: ILLiadClient.new)

--- a/models/item.rb
+++ b/models/item.rb
@@ -49,10 +49,10 @@ class InterlibraryLoanItem < Item
               @parsed_response["PhotoArticleAuthor"] || 
               @parsed_response["PhotoJournalAuthor"]
   end
-  def request_url
+  def illiad_url
     "https://ill.lib.umich.edu/illiad/illiad.dll?Action=10&Form=72&Value=#{@parsed_response["TransactionNumber"]}"
   end
-  def request_date
+  def creation_date
     @parsed_response["CreationDate"] ? DateTime.patron_format(@parsed_response["CreationDate"]) : ''
   end
   def expiration_date

--- a/models/item.rb
+++ b/models/item.rb
@@ -52,4 +52,10 @@ class InterlibraryLoanItem < Item
   def request_url
     "https://ill.lib.umich.edu/illiad/illiad.dll?Action=10&Form=72&Value=#{@parsed_response["TransactionNumber"]}"
   end
+  def request_date
+    @parsed_response["CreationDate"] ? DateTime.patron_format(@parsed_response["CreationDate"]) : ''
+  end
+  def expiration_date
+    @parsed_response["DueDate"] ? DateTime.patron_format(@parsed_response["DueDate"]) : ''
+  end
 end

--- a/models/items.rb
+++ b/models/items.rb
@@ -12,5 +12,9 @@ class Items
     @items.each do |item|
       block.call(item)
     end
-  end  
+  end
+
+  def empty?
+    count == 0
+  end
 end

--- a/models/items.rb
+++ b/models/items.rb
@@ -1,0 +1,16 @@
+class Items
+  def initialize(parsed_response)
+    @parsed_response = parsed_response
+    @items = []
+  end
+
+  def count
+    @items.length
+  end
+
+  def each(&block)
+    @items.each do |item|
+      block.call(item)
+    end
+  end  
+end

--- a/models/loans.rb
+++ b/models/loans.rb
@@ -1,8 +1,8 @@
-class Loans
+class Loans < Items
   attr_reader :pagination
   def initialize(parsed_response:, pagination:)
     @parsed_response = parsed_response
-    @list = parsed_response["item_loan"]&.map{|l| Loan.new(l)} || []
+    @items = parsed_response["item_loan"]&.map{|item| Loan.new(item)} || []
     @pagination = pagination
   end
 
@@ -29,16 +29,6 @@ class Loans
   end
   def count
     @parsed_response["total_record_count"]
-  end
-
-  def each(&block)
-    @list.each do |l|
-      block.call(l)
-    end
-  end
-
-  def empty?
-    count == 0
   end
 
 

--- a/my_account.rb
+++ b/my_account.rb
@@ -18,6 +18,7 @@ require_relative "./models/horizontal_nav"
 require_relative "./models/patron"
 require_relative "./models/item"
 require_relative "./models/loans"
+require_relative "./models/document_delivery"
 require_relative "./models/requests"
 require_relative "./models/interlibrary_loan_requests"
 require_relative "./models/fines"
@@ -93,8 +94,9 @@ namespace '/shelf' do
   end
   
   get '/document-delivery' do
-  
-    erb :document_delivery, :locals => { document_delivery: [] }
+    document_delivery = DocumentDelivery.for(uniqname: 'testhelp')
+
+    erb :document_delivery, :locals => { document_delivery: document_delivery }
   end
 end
 

--- a/my_account.rb
+++ b/my_account.rb
@@ -16,6 +16,7 @@ require_relative "./models/fine_payer"
 require_relative "./models/horizontal_nav"
 
 require_relative "./models/patron"
+require_relative "./models/items"
 require_relative "./models/item"
 require_relative "./models/loans"
 require_relative "./models/document_delivery"

--- a/spec/models/document_delivery_spec.rb
+++ b/spec/models/document_delivery_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 require 'json'
 
-describe InterlibraryLoanRequests do
+describe DocumentDelivery do
   context "one loan" do
     before(:each) do
       stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: File.read('./spec/fixtures/illiad_requests.json'))
     end
     subject do
-      InterlibraryLoanRequests.for(uniqname: 'testhelp')
+      DocumentDelivery.for(uniqname: 'testhelp')
     end
     context "#count" do
       it "returns total request item count" do
@@ -16,36 +16,36 @@ describe InterlibraryLoanRequests do
     end
     context "#each" do
       it "iterates over request objects" do
-        requests = ''
-        subject.each do |request|
-          requests = requests + request.class.name
+        document_delivery = ''
+        subject.each do |delivery|
+          document_delivery = document_delivery + delivery.class.name
         end
-        expect(requests).to eq('InterlibraryLoanRequest')
+        expect(document_delivery).to eq('DocumentDeliveryItem')
       end
     end
   end
 end
 
-describe InterlibraryLoanRequest do
+describe DocumentDeliveryItem do
   before(:each) do
-    @request = JSON.parse(File.read("./spec/fixtures/illiad_requests.json"))[2]
+    @delivery = JSON.parse(File.read("./spec/fixtures/illiad_requests.json"))[1]
   end
   subject do
-    InterlibraryLoanRequest.new(@request) 
+    DocumentDeliveryItem.new(@delivery) 
   end
   context "#title" do
     it "returns title string" do
-      expect(subject.title).to eq("What I Think")
+      expect(subject.title).to eq("Another Test Book")
     end
   end
   context "#author" do
     it "returns author string" do
-      expect(subject.author).to eq("A. Greta Mind")
+      expect(subject.author).to eq("Some Other Guy")
     end
   end
   context "#illiad_url" do
     it "returns url to the ILLiad transaction" do
-      expect(subject.illiad_url).to eq("https://ill.lib.umich.edu/illiad/illiad.dll?Action=10&Form=72&Value=3298020")
+      expect(subject.illiad_url).to eq("https://ill.lib.umich.edu/illiad/illiad.dll?Action=10&Form=72&Value=3298019")
     end
   end
   context "#creation_date" do

--- a/spec/models/interlibrary_loan_requests_spec.rb
+++ b/spec/models/interlibrary_loan_requests_spec.rb
@@ -33,14 +33,24 @@ describe InterlibraryLoanRequest do
   subject do
     InterlibraryLoanRequest.new(@request) 
   end
-  context "#request_url" do
+  context "#title" do
     it "returns url to the ILLiad transaction" do
-      expect(subject.request_url).to eq("https://ill.lib.umich.edu/illiad/illiad.dll?Action=10&Form=72&Value=3298020")
+      expect(subject.title).to eq("What I Think")
     end
   end
-  context "#request_date" do
-    it "returns request date string" do
-      expect(subject.request_date).to eq("Mar 9, 2021")
+  context "#author" do
+    it "returns url to the ILLiad transaction" do
+      expect(subject.author).to eq("A. Greta Mind")
+    end
+  end
+  context "#illiad_url" do
+    it "returns url to the ILLiad transaction" do
+      expect(subject.illiad_url).to eq("https://ill.lib.umich.edu/illiad/illiad.dll?Action=10&Form=72&Value=3298020")
+    end
+  end
+  context "#creation_date" do
+    it "returns creation date string" do
+      expect(subject.creation_date).to eq("Mar 9, 2021")
     end
   end
   context "#expiration_date" do

--- a/spec/models/interlibrary_loan_requests_spec.rb
+++ b/spec/models/interlibrary_loan_requests_spec.rb
@@ -16,11 +16,11 @@ describe InterlibraryLoanRequests do
     end
     context "#each" do
       it "iterates over request objects" do
-        requests = ''
-        subject.each do |request|
-          requests = requests + request.class.name
+        items = ''
+        subject.each do |item|
+          items = items + item.class.name
         end
-        expect(requests).to eq('InterlibraryLoanRequest')
+        expect(items).to eq('InterlibraryLoanRequest')
       end
     end
   end
@@ -28,10 +28,10 @@ end
 
 describe InterlibraryLoanRequest do
   before(:each) do
-    @request = JSON.parse(File.read("./spec/fixtures/illiad_requests.json"))[2]
+    @item = JSON.parse(File.read("./spec/fixtures/illiad_requests.json"))[2]
   end
   subject do
-    InterlibraryLoanRequest.new(@request) 
+    InterlibraryLoanRequest.new(@item) 
   end
   context "#title" do
     it "returns title string" do

--- a/spec/requests_spec.rb
+++ b/spec/requests_spec.rb
@@ -39,7 +39,9 @@ describe "requests" do
     end
   end
   context "get /shelf/document-delivery" do
-    it "contains 'Document Delivery'" do
+    it "contains 'Document delivery'" do
+      stub_illiad_get_request(url: "Transaction/UserRequests/testhelp", 
+        body: File.read("spec/fixtures/illiad_requests.json"))
       get "/shelf/document-delivery" 
       expect(last_response.body).to include("Document delivery")
     end

--- a/views/document_delivery.erb
+++ b/views/document_delivery.erb
@@ -2,7 +2,7 @@
 
 <% if document_delivery.count == 0 %>
 
-<%= erb :loanss_empty_state %>
+<%= erb :loans_empty_state %>
 
 <% elsif %>
 

--- a/views/document_delivery.erb
+++ b/views/document_delivery.erb
@@ -1,5 +1,42 @@
 <%= erb :horizontal_nav %>
 
+<% if document_delivery.count == 0 %>
+
+<%= erb :loanss_empty_state %>
+
+<% elsif %>
+
 <div class="table-container">
-  [todo]
+<table>
+  <caption>
+    <div class="loan-caption-inner-layout">
+      <p>Showing <strong><%= document_delivery.count %></strong> items</p>
+    </div>
+  </caption>
+  <thead>
+    <tr>
+      <th>Title & author</th>
+      <th>Requested</th>
+      <th>Expires</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% document_delivery.each do |delivery| %>
+      <tr>
+        <td>
+          <a href="<%= delivery.request_url %>"><%= delivery.title %></a>
+          <span>&#183; <%= delivery.author %></span>
+        </td>
+        <td>
+          <%= delivery.request_date %>
+        </td>
+        <td>
+          <%= delivery.expiration_date %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
 </div>
+
+<% end %>

--- a/views/document_delivery.erb
+++ b/views/document_delivery.erb
@@ -24,11 +24,11 @@
     <% document_delivery.each do |delivery| %>
       <tr>
         <td>
-          <a href="<%= delivery.request_url %>"><%= delivery.title %></a>
+          <a href="<%= delivery.illiad_url %>"><%= delivery.title %></a>
           <span>&#183; <%= delivery.author %></span>
         </td>
         <td>
-          <%= delivery.request_date %>
+          <%= delivery.creation_date %>
         </td>
         <td>
           <%= delivery.expiration_date %>

--- a/views/interlibrary_loan_requests.erb
+++ b/views/interlibrary_loan_requests.erb
@@ -24,11 +24,11 @@
     <% interlibrary_loan_requests.each do |interlibrary_loan_request| %>
       <tr>
         <td>
-          <a href="<%= interlibrary_loan_request.request_url %>"><%= interlibrary_loan_request.title %></a>
+          <a href="<%= interlibrary_loan_request.illiad_url %>"><%= interlibrary_loan_request.title %></a>
           <span>&#183; <%= interlibrary_loan_request.author %></span>
         </td>
         <td>
-          <%= interlibrary_loan_request.request_date %>
+          <%= interlibrary_loan_request.creation_date %>
         </td>
         <td>
           <%= interlibrary_loan_request.expiration_date %>


### PR DESCRIPTION
# Overview
Since My Account is officially pulling from the ILLiad API, we can now add information on the `Document delivery` page. This pull request adds a model and tests for the page. The view is also now displaying information.

## Future Changes
* Create a model/view for empty loan/request states.
* Create a spec for the `Item` class? One does not exist.

## Testing
* Run the tests to make sure they pass (`docker-compose run web bundle exec rspec`). Break the tests to make sure they're working.
* Check [Document delivery](http://localhost:4567/shelf/document-delivery) to see if one request shows up.
* Check the rest of the site to make sure nothing is broken.