### PR TITLE
Past Activity - Interlibrary Loans

### DIFF
--- a/models/items/interlibrary_loan/interlibrary_loan_item.rb
+++ b/models/items/interlibrary_loan/interlibrary_loan_item.rb
@@ -22,6 +22,9 @@ class InterlibraryLoanItem < Item
   def expiration_date
     @parsed_response["DueDate"] ? DateTime.patron_format(@parsed_response["DueDate"]) : ''
   end
+  def transaction_date
+    @parsed_response["TransactionDate"] ? DateTime.patron_format(@parsed_response["TransactionDate"]) : ''
+  end
   def renewable?
     @parsed_response["RenewalsAllowed"]
   end

--- a/models/items/interlibrary_loan/past_interlibrary_loans.rb
+++ b/models/items/interlibrary_loan/past_interlibrary_loans.rb
@@ -1,0 +1,23 @@
+class PastInterlibraryLoans < Items
+  def initialize(parsed_response:)
+    super
+    actions = [
+      "Cancelled",
+      "Finished"
+    ]
+    @items = parsed_response.filter_map { |item| PastInterlibraryLoan.new(item) if actions.any?{|action| item["TransactionStatus"].include?(action)}}
+  end
+
+  def self.for(uniqname:, client: ILLiadClient.new)
+    url = "/Transaction/UserRequests/#{uniqname}" 
+    response = client.get(url)
+    if response.code == 200
+      PastInterlibraryLoans.new(parsed_response: response.parsed_response)
+    else
+      #Error!
+    end
+  end
+end
+
+class PastInterlibraryLoan < InterlibraryLoanItem
+end

--- a/my_account.rb
+++ b/my_account.rb
@@ -36,6 +36,7 @@ require_relative "./models/items/interlibrary_loan/interlibrary_loan_item"
 require_relative "./models/items/interlibrary_loan/document_delivery"
 require_relative "./models/items/interlibrary_loan/interlibrary_loans"
 require_relative "./models/items/interlibrary_loan/interlibrary_loan_requests"
+require_relative "./models/items/interlibrary_loan/past_interlibrary_loans"
 
 
 helpers StyledFlash
@@ -204,7 +205,9 @@ namespace '/past-activity' do
   end
 
   get '/interlibrary-loan' do
-    erb :past_interlibrary_loans, :locals => { past_interlibrary_loans: {} }
+    past_interlibrary_loans = PastInterlibraryLoans.for(uniqname: 'testhelp')
+
+    erb :past_interlibrary_loans, :locals => { past_interlibrary_loans: past_interlibrary_loans }
   end
   get '/special-collections' do
     erb :past_special_collections, :locals => { past_special_collections: {} }

--- a/spec/models/items/interlibrary_loan/past_interlibrary_loans_spec.rb
+++ b/spec/models/items/interlibrary_loan/past_interlibrary_loans_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'json'
+
+describe PastInterlibraryLoans do
+  context "three loans" do
+    before(:each) do
+      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: File.read('./spec/fixtures/illiad_requests.json'))
+    end
+    subject do
+      PastInterlibraryLoans.for(uniqname: 'testhelp')
+    end
+    context "#count" do
+      it "returns total request item count" do
+        expect(subject.count).to eq(3)
+      end
+    end
+    context "#each" do
+      it "iterates over request objects" do
+        items = ''
+        subject.each do |item|
+          items = items + item.class.name
+        end
+        expect(items).to eq('PastInterlibraryLoanPastInterlibraryLoanPastInterlibraryLoan')
+      end
+    end
+  end
+end

--- a/spec/requests_spec.rb
+++ b/spec/requests_spec.rb
@@ -181,9 +181,11 @@ describe "requests" do
     end
   end
   context "get /past-activity/interlibrary-loan" do
-    it "exists" do
+    it "contains 'Interlibrary Loan'" do
+      stub_illiad_get_request(url: "Transaction/UserRequests/testhelp", 
+        body: File.read("spec/fixtures/illiad_requests.json"))
       get "/past-activity/interlibrary-loan" 
-      expect(last_response.status).to eq(200)
+      expect(last_response.body).to include("Interlibrary Loan")
     end
   end
   context "get /past-activity/special-collections" do

--- a/views/past_interlibrary_loans.erb
+++ b/views/past_interlibrary_loans.erb
@@ -1,5 +1,42 @@
 <%= erb :horizontal_nav %>
 
+<% if past_interlibrary_loans.count == 0 %>
+
+<%= erb :requests_empty_state %>
+
+<% elsif %>
+
 <div class="table-container">
-  [To do]
+<table>
+  <caption>
+    <div class="loan-caption-inner-layout">
+      <p>Showing <strong><%= past_interlibrary_loans.count %></strong> <%= past_interlibrary_loans.count == 1 ? "item" : "items" %></p>
+    </div>
+  </caption>
+  <thead>
+    <tr>
+      <th>Title &amp; author</th>
+      <th style="width: 9rem;">Requested</th>
+      <th style="width: 9rem;">Returned</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% past_interlibrary_loans.each do |past_interlibrary_loan| %>
+      <tr>
+        <td>
+          <a href="<%= past_interlibrary_loan.illiad_url %>"><%= past_interlibrary_loan.title %></a>
+          <span>&#183; <%= past_interlibrary_loan.author %></span>
+        </td>
+        <td>
+          <%= past_interlibrary_loan.creation_date %>
+        </td>
+        <td>
+          <%= past_interlibrary_loan.transaction_date %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
 </div>
+
+<% end %>


### PR DESCRIPTION
# Overview
`Past Activity > Interlibrary Loan` now shows `Cancelled` and `Finished` items. The model, view, and specs have been created to make this possible. This PR closes #88.

## Testing
- Run the tests to make sure they pass: `docker-compose run web bundle exec rspec`
- Break the tests to double-check that they work
- Check http://localhost:4567/past-activity/interlibrary-loan to see if it works. Check elsewhere in the site to make sure nothing is broken.