### PR TITLE
Updating date format to match mockups

### DIFF
--- a/lib/utility.rb
+++ b/lib/utility.rb
@@ -5,7 +5,7 @@ require 'securerandom'
 #App-wide formatting
 class DateTime
   def self.patron_format(date)
-    DateTime.parse(date).strftime("%b %-d, %Y")
+    DateTime.parse(date).strftime('%D')
   end
 
   def self.timestamp

--- a/spec/lib/utility_spec.rb
+++ b/spec/lib/utility_spec.rb
@@ -1,6 +1,6 @@
 describe DateTime, "patron_format('date_string')" do
   it "formats the time in the preferred way for the app" do
-    expect(DateTime.patron_format('2015-11-02T16:59:06.987Z')).to eq('Nov 2, 2015')
+    expect(DateTime.patron_format('2015-11-02T16:59:06.987Z')).to eq('11/02/15')
   end
 end
 

--- a/spec/models/fines/fines_spec.rb
+++ b/spec/models/fines/fines_spec.rb
@@ -83,7 +83,7 @@ describe Fine do
   end
   context "#date" do
     it "returns date the fine was assessed" do
-      expect(subject.date).to eq("Nov 10, 2015")
+      expect(subject.date).to eq("11/10/15")
     end
   end
   context "#id" do

--- a/spec/models/fines/receipt_spec.rb
+++ b/spec/models/fines/receipt_spec.rb
@@ -60,7 +60,7 @@ describe Receipt::Item do
   end
   context "#creation_time" do
     it "returns string" do
-      expect(subject.creation_time).to eq('Dec 9, 2020')
+      expect(subject.creation_time).to eq('12/09/20')
     end
   end
   context "#library" do

--- a/spec/models/items/alma/loans_spec.rb
+++ b/spec/models/items/alma/loans_spec.rb
@@ -146,7 +146,7 @@ describe Loan do
   end
   context "#due_date" do
     it "returns due date string" do
-      expect(subject.due_date).to eq("Jul 8, 2018")
+      expect(subject.due_date).to eq("07/08/18")
     end
   end
   context "#loan_id" do

--- a/spec/models/items/alma/requests_spec.rb
+++ b/spec/models/items/alma/requests_spec.rb
@@ -89,7 +89,7 @@ describe HoldRequest do
   end
   context "#request_date" do
     it "returns date of the request" do
-      expect(subject.request_date).to eq("Nov 2, 2020")
+      expect(subject.request_date).to eq("11/02/20")
     end
   end
   context "#pickup_location" do
@@ -107,7 +107,7 @@ describe BookingRequest do
   end
   context "#booking_date" do
     it "returns date booking is scheduled for" do
-      expect(subject.booking_date).to eq("Nov 19, 2020")
+      expect(subject.booking_date).to eq("11/19/20")
     end
   end
 end

--- a/spec/models/items/interlibrary_loan/document_delivery_spec.rb
+++ b/spec/models/items/interlibrary_loan/document_delivery_spec.rb
@@ -50,7 +50,7 @@ describe DocumentDeliveryItem do
   end
   context "#creation_date" do
     it "returns creation date string" do
-      expect(subject.creation_date).to eq("Mar 9, 2021")
+      expect(subject.creation_date).to eq("03/09/21")
     end
   end
   context "#expiration_date" do

--- a/spec/models/items/interlibrary_loan/interlibrary_loan_requests_spec.rb
+++ b/spec/models/items/interlibrary_loan/interlibrary_loan_requests_spec.rb
@@ -50,7 +50,7 @@ describe InterlibraryLoanRequest do
   end
   context "#creation_date" do
     it "returns creation date string" do
-      expect(subject.creation_date).to eq("Mar 9, 2021")
+      expect(subject.creation_date).to eq("03/09/21")
     end
   end
   context "#expiration_date" do


### PR DESCRIPTION
# Overview
While working on `Past Activity > Interlibrary Loan`, I looked at Ellen's [mockups](https://projects.invisionapp.com/d/main/default/#/projects/prototypes/20707215?newCollabSignupFlow=0&scrollOffset=1074) and saw that all of the dates were in `MM/DD/YY` format instead of `Mmm D, YYYY`. This PR updates the default date format, along with the unit tests.