### PR TITLE
Empty State View

### DIFF
--- a/config/navigation.json
+++ b/config/navigation.json
@@ -18,7 +18,11 @@
       {
         "title": "Document Delivery / Scans"
       }
-    ]
+    ],
+    "empty_state": {
+      "heading": "You don't have any loans yet.",
+      "message": "Learn more about <a href=\"https://www.lib.umich.edu/find-borrow-request/find-materials\">what you can borrow from the library</a>."
+    }
   },
   {
     "title": "Pending Requests",
@@ -30,12 +34,19 @@
         "title": "U-M Library"
       },
       {
-        "title": "Interlibrary Loan"
+        "title": "Interlibrary Loan",
+        "empty_state": {
+          "message": "View your <a href=\"\/current-checkouts\/interlibrary-loan\">interlibrary loan checkouts</a> to see if you would like to renew any items."
+        }
       },
       {
         "title": "Special Collections"
       }
-    ]
+    ],
+    "empty_state": {
+      "heading": "You don't have any pending requests.",
+      "message": "View your <a href=\"\/current-checkouts\">current checkouts</a> to see if you would like to renew any items."
+    }
   },
   {
     "title": "Past Activity",

--- a/lib/empty_state.rb
+++ b/lib/empty_state.rb
@@ -6,6 +6,13 @@ class EmptyState
     end
     @current_path = current_path
   end
+  def heading
+    get_empty_state("heading")
+  end
+  def message
+    get_empty_state("message")
+  end
+  private
   def get_empty_state(prop)
     default_state = {
       "heading" => "You have no items.",
@@ -20,11 +27,5 @@ class EmptyState
       empty_state = current_parent.children.find{|page| page.active? }.empty_state["#{prop}"] || empty_state
     end
     empty_state
-  end
-  def heading
-    self.get_empty_state("heading")
-  end
-  def message
-    self.get_empty_state("message")
   end
 end

--- a/lib/empty_state.rb
+++ b/lib/empty_state.rb
@@ -1,0 +1,30 @@
+class EmptyState
+  attr_reader :pages
+  def initialize(current_path=nil)
+    @pages = JSON.parse(File.read('./config/navigation.json')).map do |page|
+      Page.new(title: page["title"], children: page["children"], empty_state: page["empty_state"], current_path: current_path)
+    end
+    @current_path = current_path
+  end
+  def get_empty_state(prop)
+    default_state = {
+      "heading" => "You have no items.",
+      "message" => "See how you can <a href=\"https://www.lib.umich.edu/find-borrow-request\">find, borrow, or request materials<\/a> from the Library!"
+    }
+    empty_state = default_state["#{prop}"]
+    current_parent = @pages.find{|p| p.active?}
+    if current_parent.empty_state != nil
+      empty_state = current_parent.empty_state["#{prop}"] || empty_state
+    end
+    if current_parent.children.find{|page| page.active? }.empty_state != nil
+      empty_state = current_parent.children.find{|page| page.active? }.empty_state["#{prop}"] || empty_state
+    end
+    empty_state
+  end
+  def heading
+    self.get_empty_state("heading")
+  end
+  def message
+    self.get_empty_state("message")
+  end
+end

--- a/lib/empty_state.rb
+++ b/lib/empty_state.rb
@@ -13,10 +13,10 @@ class EmptyState
     }
     empty_state = default_state["#{prop}"]
     current_parent = @pages.find{|p| p.active?}
-    if current_parent.empty_state != nil
+    if current_parent.empty_state
       empty_state = current_parent.empty_state["#{prop}"] || empty_state
     end
-    if current_parent.children.find{|page| page.active? }.empty_state != nil
+    if current_parent.children.find{|page| page.active? }.empty_state
       empty_state = current_parent.children.find{|page| page.active? }.empty_state["#{prop}"] || empty_state
     end
     empty_state

--- a/lib/navigation.rb
+++ b/lib/navigation.rb
@@ -2,7 +2,7 @@ class Navigation
   attr_reader :pages
   def initialize(current_path=nil)
     @pages = JSON.parse(File.read('./config/navigation.json')).map do |p|
-      Page.new(title: p["title"], description: p["description"], icon_name: p["icon_name"], color: p["color"], children: p["children"], current_path: current_path)
+      Page.new(title: p["title"], description: p["description"], icon_name: p["icon_name"], color: p["color"], children: p["children"], empty_state: p["empty_state"], current_path: current_path)
     end
     @current_path = current_path
   end
@@ -19,15 +19,16 @@ class Navigation
   end
 end
 class Page
-  attr_reader :title, :description, :icon_name, :color, :children
-  def initialize(title:, description: nil, icon_name: nil, color: nil, children: nil, current_path: nil, parent: nil)
+  attr_reader :title, :description, :icon_name, :color, :children, :empty_state
+  def initialize(title:, description: nil, icon_name: nil, color: nil, children: nil, empty_state: nil, current_path: nil, parent: nil)
     @title = title
     @description = description
     @icon_name = icon_name
     @color = color
     @children = children&.map{ |x| 
-      Page.new(title: x["title"], parent: self, current_path: current_path)
+      Page.new(title: x["title"], empty_state: x["empty_state"], parent: self, current_path: current_path)
     }
+    @empty_state = empty_state
     @current_path = current_path
     @parent = parent
   end

--- a/my_account.rb
+++ b/my_account.rb
@@ -6,6 +6,7 @@ require "alma_rest_client"
 require 'jwt'
 require 'byebug' 
 
+require_relative "./lib/empty_state"
 require_relative "./lib/utility"
 require_relative "./lib/illiad_client"
 require_relative "./lib/navigation"

--- a/spec/lib/empty_state_spec.rb
+++ b/spec/lib/empty_state_spec.rb
@@ -1,0 +1,42 @@
+describe EmptyState do
+  context "#heading" do
+    before(:each) do
+      @current_path = nil
+    end
+    subject do
+      described_class.new(@current_path).heading
+    end
+    it "returns default empty state heading if one isn't defined in the current page or its parent" do
+      @current_path = "/past-activity/special-collections" 
+      expect(subject).to eq("You have no items.")
+    end
+    it "returns the empty state heading of the parent if one isn't define in the current page" do
+      @current_path = "/pending-requests/special-collections" 
+      expect(subject).to eq("You don\'t have any pending requests.")
+    end
+    # it "returns the empty state heading of the current page if defined" do
+    #   @current_path = "/pending-requests/interlibrary-loan" 
+    #   expect(subject).to eq("You don\'t have any pending requests.")
+    # end
+  end
+  context "#message" do
+    before(:each) do
+      @current_path = nil
+    end
+    subject do
+      described_class.new(@current_path).message
+    end
+    it "returns default empty state message if one isn't defined in the current page or its parent" do
+      @current_path = "/past-activity/special-collections" 
+      expect(subject).to eq("See how you can <a href=\"https://www.lib.umich.edu/find-borrow-request\">find, borrow, or request materials</a> from the Library!")
+    end
+    it "returns the empty state message of the parent if one isn't define in the current page" do
+      @current_path = "/pending-requests/special-collections" 
+      expect(subject).to eq("View your <a href=\"/current-checkouts\">current checkouts</a> to see if you would like to renew any items.")
+    end
+    it "returns the empty state message of the current page if defined" do
+      @current_path = "/pending-requests/interlibrary-loan" 
+      expect(subject).to eq("View your <a href=\"/current-checkouts/interlibrary-loan\">interlibrary loan checkouts</a> to see if you would like to renew any items.")
+    end
+  end
+end

--- a/views/empty_state.erb
+++ b/views/empty_state.erb
@@ -1,0 +1,12 @@
+<%
+  empty_state = EmptyState.new(request.path_info)
+%>
+
+<section class="empty-state-container">
+  <div>
+    <h2><%=empty_state.heading%></h2>
+    <p><%=empty_state.message%></p>
+  </div>
+
+  <img src="/not-found.png" alt="Planes with spotlights." />
+</section>

--- a/views/interlibrary_loan_requests.erb
+++ b/views/interlibrary_loan_requests.erb
@@ -2,7 +2,7 @@
 
 <% if interlibrary_loan_requests.count == 0 %>
 
-<%= erb :requests_empty_state %>
+<%= erb :empty_state %>
 
 <% elsif %>
 

--- a/views/interlibrary_loans.erb
+++ b/views/interlibrary_loans.erb
@@ -2,7 +2,7 @@
 
 <% if interlibrary_loans.count == 0 %>
 
-<%= erb :requests_empty_state %>
+<%= erb :empty_state %>
 
 <% elsif %>
 

--- a/views/loans_empty_state.erb
+++ b/views/loans_empty_state.erb
@@ -1,8 +1,0 @@
-<section class="empty-state-container">
-  <div>
-    <h2>You don't have any loans yet.</h2>
-    <p>Learn more about <a href="https://www.lib.umich.edu/find-borrow-request/find-materials">what you can borrow from the library</a>.</p>
-  </div>
-
-  <img src="/not-found.png" alt="" />
-</section>

--- a/views/past_interlibrary_loans.erb
+++ b/views/past_interlibrary_loans.erb
@@ -2,7 +2,7 @@
 
 <% if past_interlibrary_loans.count == 0 %>
 
-<%= erb :requests_empty_state %>
+<%= erb :empty_state %>
 
 <% elsif %>
 

--- a/views/past_loans.erb
+++ b/views/past_loans.erb
@@ -2,7 +2,7 @@
 
 <% if past_loans.count == 0 %>
 
-<%= erb :loans_empty_state %>
+<%= erb :empty_state %>
 
 <% elsif %>
 

--- a/views/requests.erb
+++ b/views/requests.erb
@@ -2,7 +2,7 @@
 
 <% if requests.count == 0 %>
 
-<%= erb :requests_empty_state %>
+<%= erb :empty_state %>
 
 <% elsif %>
 

--- a/views/requests_empty_state.erb
+++ b/views/requests_empty_state.erb
@@ -1,8 +1,0 @@
-<section class="empty-state-container">
-  <div>
-    <h2>You don't have any requests.</h2>
-    <p>Check out the <a href="/shelf">Shelf</a> to see if you would like to renew any items.</p>
-  </div>
-
-  <img src="/not-found.png" alt="" />
-</section>

--- a/views/shelf.erb
+++ b/views/shelf.erb
@@ -2,7 +2,7 @@
 
 <% if loans.count == 0 %>
 
-<%= erb :loans_empty_state %>
+<%= erb :empty_state %>
 
 <% elsif %>
 


### PR DESCRIPTION
# Overview
_One empty state to rule them all_...

The heading and message text of the empty state is controlled through `./config/navigation.json`. If the current page does not have the `empty_state` property, it falls back on reading its parent's `empty_state` property. If the parent does not have the property, it falls back to the default value defined in `./lib/empty_state.rb`. 

Possibly resolves #87?

## Wording
The wording is not final, but this new feature will allow us to easily make updates for any future content changes.

## Testing
- Run the tests to make sure they pass: `docker-compose run web bundle exec rspec`
- Break the tests to double-check that they work
- Check these pages to see them in action:
  - http://localhost:4567/pending-requests/interlibrary-loan
  - http://localhost:4567/pending-requests/special-collections
- Play around with `./config/navigation.json` and `./lib/empty_state.rb` to see how they get updated.