### PR TITLE
Updating Horizontal Nav

### DIFF
--- a/config/navigation.json
+++ b/config/navigation.json
@@ -95,6 +95,11 @@
     "description": "View and pay fines for overdue, lost, and damaged items.",
     "icon_name": "attach-money",
     "color": "indigo",
+    "children": [
+      {
+        "title": "Receipt"
+      }
+    ],
     "empty_state": {
       "heading": "You don't have any fines.",
       "message": "Fines are charged for overdue, lost, and damaged items."

--- a/lib/navigation.rb
+++ b/lib/navigation.rb
@@ -17,6 +17,9 @@ class Navigation
       HorizontalNav.new(top_level_page)
     end
   end
+  def title
+    @pages.detect{|page| page.active? }.title
+  end
 end
 class Page
   attr_reader :title, :description, :icon_name, :color, :children, :empty_state
@@ -66,15 +69,15 @@ class Page
   end
 end
 class HorizontalNav
-  attr_reader :pages
+  attr_reader :children
   def initialize(parent)
     @parent = parent
-    @pages = parent.children
+    @children = parent.children
   end
   def section
     @parent.title
   end
   def title
-    @pages.detect{|page| page.active? }.title
+    @children.detect{|child| child.active? }.title
   end
 end

--- a/lib/navigation.rb
+++ b/lib/navigation.rb
@@ -11,7 +11,7 @@ class Navigation
   end
   def horizontal_nav
     path_elements = @current_path&.split('/')[1..-1] || []
-    if path_elements.count == 2
+    if path_elements.count == 2 && !@current_path.match?('/fines-and-fees/receipt')
       top_level_slug = path_elements.first
       top_level_page = @pages.find{|x| x.slug == top_level_slug }
       HorizontalNav.new(top_level_page)

--- a/spec/lib/navigation_spec.rb
+++ b/spec/lib/navigation_spec.rb
@@ -22,12 +22,24 @@ describe Navigation do
     end
     it "returns HorizontalNav with correct number of child page and correct section" do
       @current_path = '/current-checkouts/checkouts' 
-      expect(subject.pages.count).to eq(3)
+      expect(subject.children.count).to eq(3)
       expect(subject.section).to eq('Current Checkouts')
     end
     it "doesn't return a horizonal nav for a top level page" do
       @current_path = '/current-checkouts'
       expect(subject).to be_nil
+    end
+  end
+  context "#title" do
+    before(:each) do
+      @current_path = nil
+    end
+    subject do
+      described_class.new(@current_path).title
+    end
+    it "returns the active page's title" do
+      @current_path = '/fines-and-fees'
+      expect(subject).to eq('Fines and Fees')
     end
   end
 end

--- a/spec/lib/navigation_spec.rb
+++ b/spec/lib/navigation_spec.rb
@@ -29,6 +29,10 @@ describe Navigation do
       @current_path = '/current-checkouts'
       expect(subject).to be_nil
     end
+    it "doesn't return a horizontal nav for /fines-and-fess/receipt" do
+      @current_path = '/fines-and-fees/receipt'
+      expect(subject).to be_nil
+    end
   end
   context "#title" do
     before(:each) do

--- a/views/document_delivery.erb
+++ b/views/document_delivery.erb
@@ -1,5 +1,3 @@
-<%= erb :horizontal_nav %>
-
 <% if document_delivery.count == 0 %>
 
 <%= erb :loans_empty_state %>

--- a/views/favorites.erb
+++ b/views/favorites.erb
@@ -1,5 +1,3 @@
-<h1>Favorites</h1>
-
 <% if favorites.count == 0 %>
 
 <%= erb :empty_state %>

--- a/views/fines.erb
+++ b/views/fines.erb
@@ -1,5 +1,3 @@
-<h1>Fines and Fees</h1>
-
 <% if fines.count == 0 %>
 
 <%= erb :empty_state %>

--- a/views/home.erb
+++ b/views/home.erb
@@ -1,5 +1,3 @@
-<h1>Account Overview</h1>
-
 <!--
   Could this data come from back-end?
 

--- a/views/horizontal_nav.erb
+++ b/views/horizontal_nav.erb
@@ -3,7 +3,7 @@
   horizontal_nav = nav.horizontal_nav
 %>
 
-<% if horizontal_nav.nil? %>
+<% if horizontal_nav.nil? || horizontal_nav.section == 'Fines and Fees' %>
 
   <h1><%=nav.title%></h1>
 

--- a/views/horizontal_nav.erb
+++ b/views/horizontal_nav.erb
@@ -3,7 +3,7 @@
   horizontal_nav = nav.horizontal_nav
 %>
 
-<% if horizontal_nav.nil? || horizontal_nav.section == 'Fines and Fees' %>
+<% if horizontal_nav.nil?%>
 
   <h1><%=nav.title%></h1>
 

--- a/views/horizontal_nav.erb
+++ b/views/horizontal_nav.erb
@@ -1,19 +1,28 @@
 <%
-  nav = Navigation.new(request.path_info).horizontal_nav
+  nav = Navigation.new(request.path_info)
+  horizontal_nav = nav.horizontal_nav
 %>
 
-<h1 aria-hidden="true"><%=nav.section%></h1>
+<% if horizontal_nav.nil? %>
 
-<nav aria-labelledby="main-heading" class="horizontal-navigation-container">
-  <h1 class="h2 horizontal-heading" id="main-heading"><span class="visually-hidden"><%=nav.section%>: </span><%=nav.title%></h1>
+  <h1><%=nav.title%></h1>
 
-  <ul class="horizontal-navigation-list">
-      <% nav.pages.each do |page| %>
-        <li>
-          <a href="<%=page.path%>" class="<%=page.active%>" >
-            <%=page.title%>
-          </a>
-        </li>
-      <% end %>
-  </ul>
-</nav>
+<% else %>
+
+  <h1 aria-hidden="true"><%=horizontal_nav.section%></h1>
+
+  <nav aria-labelledby="main-heading" class="horizontal-navigation-container">
+    <h1 class="h2 horizontal-heading" id="main-heading"><span class="visually-hidden"><%=horizontal_nav.section%>: </span><%=horizontal_nav.title%></h1>
+
+    <ul class="horizontal-navigation-list">
+        <% horizontal_nav.children.each do |child| %>
+          <li>
+            <a href="<%=child.path%>" class="<%=child.active%>" >
+              <%=child.title%>
+            </a>
+          </li>
+        <% end %>
+    </ul>
+  </nav>
+
+<% end %>

--- a/views/interlibrary_loan_requests.erb
+++ b/views/interlibrary_loan_requests.erb
@@ -1,5 +1,3 @@
-<%= erb :horizontal_nav %>
-
 <% if interlibrary_loan_requests.count == 0 %>
 
 <%= erb :empty_state %>

--- a/views/interlibrary_loans.erb
+++ b/views/interlibrary_loans.erb
@@ -1,5 +1,3 @@
-<%= erb :horizontal_nav %>
-
 <% if interlibrary_loans.count == 0 %>
 
 <%= erb :empty_state %>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -28,6 +28,7 @@
     <main class="layout site-layout">
       <%= erb :navigation %>
       <article class="site-layout__center owl prose">
+        <%= erb :horizontal_nav %>
         <%= patron_styled_flash %>
 
         <%= yield %>

--- a/views/past_interlibrary_loans.erb
+++ b/views/past_interlibrary_loans.erb
@@ -1,5 +1,3 @@
-<%= erb :horizontal_nav %>
-
 <% if past_interlibrary_loans.count == 0 %>
 
 <%= erb :empty_state %>

--- a/views/past_loans.erb
+++ b/views/past_loans.erb
@@ -1,5 +1,3 @@
-<%= erb :horizontal_nav %>
-
 <% if past_loans.count == 0 %>
 
 <%= erb :empty_state %>

--- a/views/past_special_collections.erb
+++ b/views/past_special_collections.erb
@@ -1,5 +1,3 @@
-<%= erb :horizontal_nav %>
-
 <div class="table-container">
   <p>You must visit <a href="http://iris.lib.umich.edu/aeon/">your Special Collections account</a> to renew or get more info on Special Collection items.</p>
 </div>

--- a/views/patron.erb
+++ b/views/patron.erb
@@ -1,5 +1,3 @@
-<h1>Contact information</h1>
-
 <div class="owl narrow-content">
 
   <p>You can update your name and address at <a href="https://wolverineaccess.umich.edu/task/all/campus-personal-info">Wolverine Access</a>.</p>

--- a/views/receipt.erb
+++ b/views/receipt.erb
@@ -1,5 +1,3 @@
-<h1>Payment summary</h1>
-
 <% if receipt.valid? %>
   <p>Please review the details for this transaction.</p>
   <h2>Your details</h2>

--- a/views/requests.erb
+++ b/views/requests.erb
@@ -1,10 +1,10 @@
-<%= erb :horizontal_nav %>
-<h3>Hold Requests</h4>
 <% if holds.count == 0 %>
 
 <%= erb :empty_state %>
 
 <% elsif %>
+
+<h3>Hold Requests</h3>
 
 <div class="table-container">
 <table>

--- a/views/shelf.erb
+++ b/views/shelf.erb
@@ -1,5 +1,3 @@
-<%= erb :horizontal_nav %>
-
 <% if loans.count == 0 %>
 
 <%= erb :empty_state %>


### PR DESCRIPTION
# Overview
Horizontal Nav has been updated so that if there are child pages, show the navigation. If not, show the current page title. All titles are now officially controlled in the `config.json` file. The view has been moved to the `layout` view so that every page will have it.

## Testing
- Run the tests to make sure they pass: `docker-compose run web bundle exec rspec`
  - Break the tests to double-check that they work
- Check all pages to see if nothing is broken.