### PR TITLE
Current Checkouts > Interlibrary Loan Pagination

### DIFF
--- a/models/items/interlibrary_loan/interlibrary_loan_item.rb
+++ b/models/items/interlibrary_loan/interlibrary_loan_item.rb
@@ -36,7 +36,11 @@ class InterlibraryLoanItem < Item
     @parsed_response["DueDate"] ? DateTime.patron_format(@parsed_response["DueDate"]) : ''
   end
   def due_status
-    LoanDate.parse(@parsed_response["DueDate"]).due_status
+    if @parsed_response["DueDate"].nil?
+      ""
+    else
+      LoanDate.parse(@parsed_response["DueDate"]).due_status
+    end
   end
   def transaction_date
     @parsed_response["TransactionDate"] ? DateTime.patron_format(@parsed_response["TransactionDate"]) : ''

--- a/models/items/interlibrary_loan/interlibrary_loans.rb
+++ b/models/items/interlibrary_loan/interlibrary_loans.rb
@@ -1,19 +1,29 @@
 class InterlibraryLoans < Items
-  def initialize(parsed_response:)
+  attr_reader :pagination
+  def initialize(parsed_response:, pagination:)
     super
-    @items = parsed_response.filter_map { |item| InterlibraryLoan.new(item) if item["RequestType"] == "Loan" && item["TransactionStatus"] == "Checked Out to Customer" }
+    @items = parsed_response.filter_map { |item| InterlibraryLoan.new(item) if item["RequestType"] == "Loan" && item["TransactionStatus"] == "Checked Out to Customer" } || []
+    @pagination = pagination
   end
 
-  def self.for(uniqname:, client: ILLiadClient.new)
+  def self.for(uniqname:, offset: nil, limit: 15, client: ILLiadClient.new)
     url = "/Transaction/UserRequests/#{uniqname}" 
+    query = {}
+    query["offset"] = offset unless offset.nil?
+
+    limit.nil? ? query["limit"] = 15 : query["limit"] = limit
+    
     #TBDeleted 
     fake_data = JSON.parse(File.read('./spec/fixtures/illiad_requests.json'))
     fake_data[1]["RenewalsAllowed"] = true
     fake_data[1]["DueDate"] = "2022-06-02T00:00:00"
 
-    response = client.get(url)
+    response = client.get(url, query)
     if response.code == 200
-      InterlibraryLoans.new(parsed_response: fake_data) #should be response.parsed_response
+      pagination_params = { url: "/current-checkouts/interlibrary-loan", total: fake_data.count }
+      pagination_params[:limit] = limit unless limit.nil?
+      pagination_params[:current_offset] = offset unless offset.nil?
+      InterlibraryLoans.new(parsed_response: fake_data, pagination: PaginationDecorator.new(**pagination_params)) #should be response.parsed_response
     else
       #Error!
     end

--- a/models/items/interlibrary_loan/interlibrary_loans.rb
+++ b/models/items/interlibrary_loan/interlibrary_loans.rb
@@ -1,33 +1,24 @@
-class InterlibraryLoans < Items
-  attr_reader :pagination
-  def initialize(parsed_response:, pagination:)
+class InterlibraryLoans < InterlibraryLoanItems
+  attr_reader :pagination, :count
+  def initialize(parsed_response:, pagination:, count: nil)
     super
-    @items = parsed_response.filter_map { |item| InterlibraryLoan.new(item) if item["RequestType"] == "Loan" && item["TransactionStatus"] == "Checked Out to Customer" } || []
+    @items = parsed_response.map { |item| InterlibraryLoan.new(item) }
     @pagination = pagination
+    @count = count
   end
 
-  def self.for(uniqname:, skip: nil, top: 15, client: ILLiadClient.new)
-    url = "/Transaction/UserRequests/#{uniqname}" 
-    query = {}
-    query["skip"] = skip unless skip.nil?
 
-    top.nil? ? query["top"] = 15 : query["top"] = top
-    
-    #TBDeleted 
-    fake_data = JSON.parse(File.read('./spec/fixtures/illiad_requests.json'))
-    fake_data[1]["RenewalsAllowed"] = true
-    fake_data[1]["DueDate"] = "2022-06-02T00:00:00"
-
-    response = client.get(url, query)
-    if response.code == 200
-      pagination_params = { url: "/current-checkouts/interlibrary-loan", total: fake_data.count }
-      pagination_params[:limit] = top unless top.nil?
-      pagination_params[:current_offset] = skip unless skip.nil?
-      InterlibraryLoans.new(parsed_response: fake_data, pagination: PaginationDecorator.new(**pagination_params)) #should be response.parsed_response
-    else
-      #Error!
-    end
+  private
+  def self.illiad_url(uniqname)
+    "/Transaction/UserRequests/#{uniqname}" 
   end
+  def self.url
+    "/current-checkouts/interlibrary-loan"
+  end
+  def self.filter
+    "RequestType eq 'Loan' and TransactionStatus eq 'Checked Out to Customer'"
+  end
+  
 end
 
 class InterlibraryLoan < InterlibraryLoanItem

--- a/models/items/interlibrary_loan/interlibrary_loans.rb
+++ b/models/items/interlibrary_loan/interlibrary_loans.rb
@@ -6,12 +6,12 @@ class InterlibraryLoans < Items
     @pagination = pagination
   end
 
-  def self.for(uniqname:, offset: nil, limit: 15, client: ILLiadClient.new)
+  def self.for(uniqname:, skip: nil, top: 15, client: ILLiadClient.new)
     url = "/Transaction/UserRequests/#{uniqname}" 
     query = {}
-    query["offset"] = offset unless offset.nil?
+    query["skip"] = skip unless skip.nil?
 
-    limit.nil? ? query["limit"] = 15 : query["limit"] = limit
+    top.nil? ? query["top"] = 15 : query["top"] = top
     
     #TBDeleted 
     fake_data = JSON.parse(File.read('./spec/fixtures/illiad_requests.json'))
@@ -21,8 +21,8 @@ class InterlibraryLoans < Items
     response = client.get(url, query)
     if response.code == 200
       pagination_params = { url: "/current-checkouts/interlibrary-loan", total: fake_data.count }
-      pagination_params[:limit] = limit unless limit.nil?
-      pagination_params[:current_offset] = offset unless offset.nil?
+      pagination_params[:limit] = top unless top.nil?
+      pagination_params[:current_offset] = skip unless skip.nil?
       InterlibraryLoans.new(parsed_response: fake_data, pagination: PaginationDecorator.new(**pagination_params)) #should be response.parsed_response
     else
       #Error!

--- a/my_account.rb
+++ b/my_account.rb
@@ -176,8 +176,9 @@ namespace '/current-checkouts' do
   end
   
   get '/interlibrary-loan' do
-    interlibrary_loans = InterlibraryLoans.for(uniqname: 'testhelp')
+    interlibrary_loans = InterlibraryLoans.for(uniqname: 'testhelp', limit: params["limit"], offset: params["offset"], count: session[:current_interlibrary_loans_count])
 
+    session[:current_interlibrary_loans_count] = interlibrary_loans.count if session[:current_interlibrary_loans_count].nil? 
     erb :interlibrary_loans, :locals => { interlibrary_loans: interlibrary_loans }
   end
   get '/document-delivery-or-scans' do

--- a/spec/models/items/interlibrary_loan/interlibrary_loans_spec.rb
+++ b/spec/models/items/interlibrary_loan/interlibrary_loans_spec.rb
@@ -4,7 +4,7 @@ require 'json'
 describe InterlibraryLoans do
   context "one loan" do
     before(:each) do
-      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: File.read('./spec/fixtures/illiad_requests.json'), query: {limit: 15})
+      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: File.read('./spec/fixtures/illiad_requests.json'), query: {top: 15})
     end
     subject do
       InterlibraryLoans.for(uniqname: 'testhelp')
@@ -36,10 +36,10 @@ describe InterlibraryLoans do
   end
   context "pagination" do
     before(:each) do
-      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: File.read('./spec/fixtures/illiad_requests.json'), query: {"offset" => 1, "limit" => 1} )
+      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: File.read('./spec/fixtures/illiad_requests.json'), query: {"skip" => 1, "top" => 1} )
     end
     subject do
-      InterlibraryLoans.for(uniqname: 'testhelp', offset: 1, limit: 1)
+      InterlibraryLoans.for(uniqname: 'testhelp', skip: 1, top: 1)
     end
     context "#count" do
       it "returns total count for loans" do
@@ -47,7 +47,7 @@ describe InterlibraryLoans do
       end
     end
     context "#each" do
-      it "iterates over limited number of items" do
+      it "iterates over toped number of items" do
         loans_contents = ''
         subject.each do |loan|
           loans_contents = loans_contents + loan.class.name

--- a/spec/models/items/interlibrary_loan/interlibrary_loans_spec.rb
+++ b/spec/models/items/interlibrary_loan/interlibrary_loans_spec.rb
@@ -4,7 +4,7 @@ require 'json'
 describe InterlibraryLoans do
   context "one loan" do
     before(:each) do
-      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: File.read('./spec/fixtures/illiad_requests.json'))
+      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: File.read('./spec/fixtures/illiad_requests.json'), query: {limit: 15})
     end
     subject do
       InterlibraryLoans.for(uniqname: 'testhelp')
@@ -31,6 +31,28 @@ describe InterlibraryLoans do
     context "#item_text" do
       it "returns 'item' if there is only one loan, or 'items' if there is not" do
         expect(subject.item_text).to eq('item')
+      end
+    end
+  end
+  context "pagination" do
+    before(:each) do
+      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: File.read('./spec/fixtures/illiad_requests.json'), query: {"offset" => 1, "limit" => 1} )
+    end
+    subject do
+      InterlibraryLoans.for(uniqname: 'testhelp', offset: 1, limit: 1)
+    end
+    context "#count" do
+      it "returns total count for loans" do
+        expect(subject.count).to eq(1)
+      end
+    end
+    context "#each" do
+      it "iterates over limited number of items" do
+        loans_contents = ''
+        subject.each do |loan|
+          loans_contents = loans_contents + loan.class.name
+        end
+        expect(loans_contents).to eq('InterlibraryLoan')
       end
     end
   end

--- a/spec/models/items/interlibrary_loan/interlibrary_loans_spec.rb
+++ b/spec/models/items/interlibrary_loan/interlibrary_loans_spec.rb
@@ -2,16 +2,17 @@ require 'spec_helper'
 require 'json'
 
 describe InterlibraryLoans do
-  context "one loan" do
+  let(:query){{"$filter" => "RequestType eq 'Loan' and TransactionStatus eq 'Checked Out to Customer'", "$top" => '15'}}
+  context "three loans" do
     before(:each) do
-      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: File.read('./spec/fixtures/illiad_requests.json'), query: {top: 15})
+      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: File.read('./spec/fixtures/illiad_requests.json'), query: query)
     end
     subject do
-      InterlibraryLoans.for(uniqname: 'testhelp')
+      InterlibraryLoans.for(uniqname: 'testhelp', count: 25)
     end
     context "#count" do
       it "returns total request item count" do
-        expect(subject.count).to eq(1)
+        expect(subject.count).to eq(25)
       end
     end
     context "#each" do
@@ -20,7 +21,7 @@ describe InterlibraryLoans do
         subject.each do |item|
           items = items + item.class.name
         end
-        expect(items).to eq('InterlibraryLoan')
+        expect(items).to eq("InterlibraryLoan"*5)
       end
     end
     context "#empty?" do
@@ -30,29 +31,29 @@ describe InterlibraryLoans do
     end
     context "#item_text" do
       it "returns 'item' if there is only one loan, or 'items' if there is not" do
-        expect(subject.item_text).to eq('item')
+        expect(subject.item_text).to eq('items')
       end
     end
   end
-  context "pagination" do
+  context "no count given" do
     before(:each) do
-      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: File.read('./spec/fixtures/illiad_requests.json'), query: {"skip" => 1, "top" => 1} )
+      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: File.read('./spec/fixtures/illiad_requests.json'), query: {'$filter': query['$filter']})
     end
     subject do
-      InterlibraryLoans.for(uniqname: 'testhelp', skip: 1, top: 1)
+      InterlibraryLoans.for(uniqname: 'testhelp', limit: '1', count: nil)
     end
     context "#count" do
-      it "returns total count for loans" do
-        expect(subject.count).to eq(1)
+      it "returns total number of transactions" do
+        expect(subject.count).to eq(5)
       end
-    end
+    end 
     context "#each" do
-      it "iterates over toped number of items" do
-        loans_contents = ''
-        subject.each do |loan|
-          loans_contents = loans_contents + loan.class.name
+      it "returns limit number of Loan objects" do
+        items = ''
+        subject.each do |item|
+          items = items + item.class.name
         end
-        expect(loans_contents).to eq('InterlibraryLoan')
+        expect(items).to eq("InterlibraryLoan"*1)
       end
     end
   end

--- a/spec/requests_spec.rb
+++ b/spec/requests_spec.rb
@@ -137,7 +137,7 @@ describe "requests" do
   context "get /current-checkouts/interlibrary-loan" do
     it "contains 'Interlibrary Loan'" do
       stub_illiad_get_request(url: "Transaction/UserRequests/testhelp", 
-        body: File.read("spec/fixtures/illiad_requests.json"))
+        body: File.read("spec/fixtures/illiad_requests.json"), query: {limit: 15})
       get "/current-checkouts/interlibrary-loan" 
       expect(last_response.body).to include("Interlibrary Loan")
     end

--- a/spec/requests_spec.rb
+++ b/spec/requests_spec.rb
@@ -136,8 +136,9 @@ describe "requests" do
   
   context "get /current-checkouts/interlibrary-loan" do
     it "contains 'Interlibrary Loan'" do
+      query = {"$filter" => "RequestType eq 'Loan' and TransactionStatus eq 'Checked Out to Customer'"}
       stub_illiad_get_request(url: "Transaction/UserRequests/testhelp", 
-        body: File.read("spec/fixtures/illiad_requests.json"), query: {top: 15})
+        body: File.read("spec/fixtures/illiad_requests.json"), query: query)
       get "/current-checkouts/interlibrary-loan" 
       expect(last_response.body).to include("Interlibrary Loan")
     end

--- a/spec/requests_spec.rb
+++ b/spec/requests_spec.rb
@@ -137,7 +137,7 @@ describe "requests" do
   context "get /current-checkouts/interlibrary-loan" do
     it "contains 'Interlibrary Loan'" do
       stub_illiad_get_request(url: "Transaction/UserRequests/testhelp", 
-        body: File.read("spec/fixtures/illiad_requests.json"), query: {limit: 15})
+        body: File.read("spec/fixtures/illiad_requests.json"), query: {top: 15})
       get "/current-checkouts/interlibrary-loan" 
       expect(last_response.body).to include("Interlibrary Loan")
     end

--- a/views/interlibrary_loans.erb
+++ b/views/interlibrary_loans.erb
@@ -8,7 +8,7 @@
 <table>
   <caption>
     <div class="loan-caption-inner-layout">
-      <p>Showing <strong><%= interlibrary_loans.count %></strong> <%= interlibrary_loans.item_text %></p>
+      <p>Showing <strong><%=interlibrary_loans.pagination.first%></strong> - <strong><%=interlibrary_loans.pagination.last%></strong> of <strong><%= interlibrary_loans.count %></strong> <%= interlibrary_loans.item_text %></p>
     </div>
   </caption>
   <thead>
@@ -44,5 +44,7 @@
   </tbody>
 </table>
 </div>
+
+<%= erb :pagination, locals: {pagination: interlibrary_loans.pagination, count: interlibrary_loans.count} %>
 
 <% end %>


### PR DESCRIPTION
# Overview
Adding pagination to `Current Checkouts > Interlibrary Loan`.

Resolves #72.

## Problem
There is only one loan that shows in the list. However, the "Showing..." portion says `Showing 1 - 5 of 1 item`, when there's only one item. It comes from `pagination.last`.