### PR TITLE
Current Checkouts > Scans and Electronic Items Pagination

### DIFF
--- a/config/navigation.json
+++ b/config/navigation.json
@@ -23,9 +23,9 @@
         }
       },
       {
-        "title": "Document Delivery / Scans",
+        "title": "Scans and Electronic Items",
         "empty_state": {
-          "heading": "You don't have any scans to view or download.",
+          "heading": "You don't have any material to view or download.",
           "message": "See how you can <a href=\"https://www.lib.umich.edu/find-borrow-request/request-digital-copies-or-duplication/scans\">request a scan</a> for small portions of physical items such as book chapters or articles."
         }
       }

--- a/models/items/interlibrary_loan/document_delivery.rb
+++ b/models/items/interlibrary_loan/document_delivery.rb
@@ -1,18 +1,24 @@
-class DocumentDelivery < Items
-  def initialize(parsed_response:)
+class DocumentDelivery < InterlibraryLoanItems
+  attr_reader :pagination, :count
+  def initialize(parsed_response:, pagination:, count: nil)
     super
-    @items = parsed_response.filter_map { |item| DocumentDeliveryItem.new(item) if item["RequestType"] == "Loan" && item["TransactionStatus"] != "Request Finished" }
+    @items = parsed_response.map { |item| DocumentDeliveryItem.new(item) }
+    @pagination = pagination
+    @count = count
   end
 
-  def self.for(uniqname:, client: ILLiadClient.new)
-    url = "/Transaction/UserRequests/#{uniqname}" 
-    response = client.get(url)
-    if response.code == 200
-      DocumentDelivery.new(parsed_response: response.parsed_response)
-    else
-      #Error!
-    end
+
+  private
+  def self.illiad_url(uniqname)
+    "/Transaction/UserRequests/#{uniqname}" 
   end
+  def self.url
+    "/current-checkouts/document-delivery-or-scans"
+  end
+  def self.filter
+    "RequestType eq 'Loan' and TransactionStatus ne 'Request Finished'"
+  end
+  
 end
 
 class DocumentDeliveryItem < InterlibraryLoanItem

--- a/my_account.rb
+++ b/my_account.rb
@@ -180,7 +180,7 @@ namespace '/current-checkouts' do
 
     erb :interlibrary_loans, :locals => { interlibrary_loans: interlibrary_loans }
   end
-  get '/document-delivery-or-scans' do
+  get '/scans-and-electronic-items' do
     document_delivery = DocumentDelivery.for(uniqname: 'testhelp')
 
     erb :document_delivery, :locals => { document_delivery: document_delivery }

--- a/spec/models/items/interlibrary_loan/document_delivery_spec.rb
+++ b/spec/models/items/interlibrary_loan/document_delivery_spec.rb
@@ -2,25 +2,26 @@ require 'spec_helper'
 require 'json'
 
 describe DocumentDelivery do
-  context "one loan" do
+  let(:query){{"$filter" => "RequestType eq 'Loan' and TransactionStatus ne 'Request Finished'", "$top" => '15'}}
+  context "three loans" do
     before(:each) do
-      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: File.read('./spec/fixtures/illiad_requests.json'))
+      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: File.read('./spec/fixtures/illiad_requests.json'), query: query)
     end
     subject do
-      DocumentDelivery.for(uniqname: 'testhelp')
+      DocumentDelivery.for(uniqname: 'testhelp', count: 25)
     end
     context "#count" do
       it "returns total request item count" do
-        expect(subject.count).to eq(1)
+        expect(subject.count).to eq(25)
       end
     end
     context "#each" do
       it "iterates over request objects" do
-        document_delivery = ''
-        subject.each do |delivery|
-          document_delivery = document_delivery + delivery.class.name
+        items = ''
+        subject.each do |item|
+          items = items + item.class.name
         end
-        expect(document_delivery).to eq('DocumentDeliveryItem')
+        expect(items).to eq("DocumentDeliveryItem"*5)
       end
     end
     context "#empty?" do
@@ -30,72 +31,30 @@ describe DocumentDelivery do
     end
     context "#item_text" do
       it "returns 'item' if there is only one loan, or 'items' if there is not" do
-        expect(subject.item_text).to eq('item')
+        expect(subject.item_text).to eq('items')
       end
     end
   end
-end
-
-describe DocumentDeliveryItem do
-  before(:each) do
-    @delivery = JSON.parse(File.read("./spec/fixtures/illiad_requests.json"))[1]
-  end
-  subject do
-    DocumentDeliveryItem.new(@delivery) 
-  end
-  context "#title" do
-    it "returns title string" do
-      expect(subject.title).to eq("Another Test Book")
+  context "no count given" do
+    before(:each) do
+      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: File.read('./spec/fixtures/illiad_requests.json'), query: {'$filter': query['$filter']})
     end
-  end
-  context "#author" do
-    it "returns author string" do
-      expect(subject.author).to eq("Some Other Guy")
+    subject do
+      DocumentDelivery.for(uniqname: 'testhelp', limit: '1', count: nil)
     end
-  end
-  context "#illiad_id" do
-    it "returns the ILLiad transaction ID" do
-      expect(subject.illiad_id).to eq(3298019)
-    end
-  end
-  context "#illiad_url" do
-    it "returns ILLIAD url based on action number, form number, and if the form is actually type" do
-      expect(subject.illiad_url(42, 1887, true)).to eq("https://ill.lib.umich.edu/illiad/illiad.dll?Action=42&Type=1887&Value=3298019")
-    end
-  end
-  context "#url_transaction" do
-    it "returns url to the ILLiad transaction" do
-      expect(subject.url_transaction).to eq("https://ill.lib.umich.edu/illiad/illiad.dll?Action=10&Form=72&Value=3298019")
-    end
-  end
-  context "#url_cancel_request" do
-    it "returns url to cancel the ILLiad transaction request" do
-      expect(subject.url_cancel_request).to eq("https://ill.lib.umich.edu/illiad/illiad.dll?Action=21&Type=10&Value=3298019")
-    end
-  end
-  context "#url_request_renewal" do
-    it "returns url to the form to request a renewal of the ILLiad transaction" do
-      expect(subject.url_request_renewal).to eq("https://ill.lib.umich.edu/illiad/illiad.dll?Action=11&Form=71&Value=3298019")
-    end
-  end
-  context "#creation_date" do
-    it "returns creation date string" do
-      expect(subject.creation_date).to eq("03/09/21")
-    end
-  end
-  context "#expiration_date" do
-    it "returns expiration date string" do
-      expect(subject.expiration_date).to eq('')
-    end
-  end
-  context "#transaction_date" do
-    it "returns transaction date string" do
-      expect(subject.transaction_date).to eq("03/09/21")
-    end
-  end
-  context "#renewable?" do
-    it "returns a boolean" do
-      expect(subject.renewable?).to eq(false)
+    context "#count" do
+      it "returns total number of transactions" do
+        expect(subject.count).to eq(5)
+      end
+    end 
+    context "#each" do
+      it "returns limit number of Loan objects" do
+        items = ''
+        subject.each do |item|
+          items = items + item.class.name
+        end
+        expect(items).to eq("DocumentDeliveryItem"*1)
+      end
     end
   end
 end

--- a/spec/requests_spec.rb
+++ b/spec/requests_spec.rb
@@ -144,8 +144,9 @@ describe "requests" do
   end
   context "get /current-checkouts/document-delivery-or-scans" do
     it "contains 'Document Delivery / Scans'" do
+      query = {"$filter" => "RequestType eq 'Loan' and TransactionStatus ne 'Request Finished'"}
       stub_illiad_get_request(url: "Transaction/UserRequests/testhelp", 
-        body: File.read("spec/fixtures/illiad_requests.json"))
+        body: File.read("spec/fixtures/illiad_requests.json"), query: query)
       get "/current-checkouts/document-delivery-or-scans" 
       expect(last_response.body).to include("Document Delivery / Scans")
     end

--- a/spec/requests_spec.rb
+++ b/spec/requests_spec.rb
@@ -142,13 +142,13 @@ describe "requests" do
       expect(last_response.body).to include("Interlibrary Loan")
     end
   end
-  context "get /current-checkouts/document-delivery-or-scans" do
-    it "contains 'Document Delivery / Scans'" do
+  context "get /current-checkouts/scans-and-electronic-items" do
+    it "contains 'Scans and Electronic Items'" do
       query = {"$filter" => "RequestType eq 'Loan' and TransactionStatus ne 'Request Finished'"}
       stub_illiad_get_request(url: "Transaction/UserRequests/testhelp", 
         body: File.read("spec/fixtures/illiad_requests.json"), query: query)
-      get "/current-checkouts/document-delivery-or-scans" 
-      expect(last_response.body).to include("Document Delivery / Scans")
+      get "/current-checkouts/scans-and-electronic-items" 
+      expect(last_response.body).to include("Scans and Electronic Items")
     end
   end
   context "get /pending-requests" do

--- a/views/document_delivery.erb
+++ b/views/document_delivery.erb
@@ -8,7 +8,7 @@
 <table>
   <caption>
     <div class="loan-caption-inner-layout">
-      <p>Showing <strong><%= document_delivery.count %></strong> <%= document_delivery.item_text %></p>
+      <p>Showing <strong><%= document_delivery.pagination.first %></strong> - <strong><%= document_delivery.pagination.last %></strong> of <strong><%= document_delivery.count %></strong> <%= document_delivery.item_text %></p>
     </div>
   </caption>
   <thead>
@@ -40,5 +40,7 @@
   </tbody>
 </table>
 </div>
+
+<%= erb :pagination, locals: {pagination: document_delivery.pagination, count: document_delivery.count} %>
 
 <% end %>


### PR DESCRIPTION
# Overview
Adding pagination to `Current Checkouts > Scans and Electronic Items`.

Resolves #76.

## Testing
- Run the tests to make sure they pass: `docker-compose run web bundle exec rspec`
  - Break the tests to double-check that they work
- Check out [Current Checkouts > Scans and Electronic Items](http://localhost:4567/current-checkouts/scans-and-electronic-items?limit=1) and play around with the limit to make sure pagination works.