### PR TITLE
Renaming 'Actions' Columns

### DIFF
--- a/views/document_delivery.erb
+++ b/views/document_delivery.erb
@@ -15,7 +15,7 @@
     <tr>
       <th>Title & author</th>
       <th style="width: 9rem;">Due date</th>
-      <th style="width: 5rem;">Actions</th>
+      <th style="width: 5rem;">Action</th>
     </tr>
   </thead>
   <tbody>

--- a/views/interlibrary_loan_requests.erb
+++ b/views/interlibrary_loan_requests.erb
@@ -15,7 +15,7 @@
     <tr>
       <th>Title & author</th>
       <th style="width: 9rem;">Request date</th>
-      <th style="width: 6rem;">Actions</th>
+      <th style="width: 6rem;">Action</th>
     </tr>
   </thead>
   <tbody>

--- a/views/interlibrary_loans.erb
+++ b/views/interlibrary_loans.erb
@@ -15,7 +15,7 @@
     <tr>
       <th>Title &amp; author</th>
       <th style="width: 9rem;">Due date</th>
-      <th style="width: 5rem;">Actions</th>
+      <th style="width: 5rem;">Action</th>
     </tr>
   </thead>
   <tbody>

--- a/views/requests.erb
+++ b/views/requests.erb
@@ -13,7 +13,7 @@
       <th>Title & author</th>
       <th style="width: 9rem;">Pickup location</th>
       <th style="width: 9rem;">Request date</th>
-      <th style="width: 6rem;">Actions</th>
+      <th style="width: 6rem;">Action</th>
     </tr>
   </thead>
   <tbody>
@@ -48,7 +48,7 @@
       <th>Title & author</th>
       <th style="width: 9rem;">Pickup location</th>
       <th style="width: 9rem;">Pickup date</th>
-      <th style="width: 6rem;">Actions</th>
+      <th style="width: 6rem;">Action</th>
     </tr>
   </thead>
   <tbody>

--- a/views/shelf.erb
+++ b/views/shelf.erb
@@ -44,7 +44,7 @@
     <tr>
       <th>Title & author</th>
       <th style="width: 9rem;">Due date</th>
-      <th style="width: 5rem;">Actions</th>
+      <th style="width: 5rem;">Action</th>
     </tr>
   </thead>
 


### PR DESCRIPTION
# Overview
Suggestion from Ellen:

> Change "Actions" column header to "Action" since it's only one action