### PR TITLE
Past Activity > Scans and Electronic Items

### DIFF
--- a/config/navigation.json
+++ b/config/navigation.json
@@ -23,9 +23,9 @@
         }
       },
       {
-        "title": "Document Delivery / Scans",
+        "title": "Scans and Electronic Items",
         "empty_state": {
-          "heading": "You don't have any scans to view or download.",
+          "heading": "You don't have any material to view or download.",
           "message": "See how you can <a href=\"https://www.lib.umich.edu/find-borrow-request/request-digital-copies-or-duplication/scans\">request a scan</a> for small portions of physical items such as book chapters or articles."
         }
       }

--- a/config/navigation.json
+++ b/config/navigation.json
@@ -80,6 +80,12 @@
         }
       },
       {
+        "title": "Scans and Electronic Items",
+        "empty_state": {
+          "message": "Once you've <a href=\"https://www.lib.umich.edu/find-borrow-request/request-digital-copies-or-duplication/scans\">requested a scan</a> for small portions of physical items such as book chapters or articles, you'll be able to see its record here."
+        }
+      },
+      {
         "title": "Special Collections",
         "empty_state": {
           "message": "Once you've viewed an item at the <a href=\"https://www.lib.umich.edu/locations-and-hours/special-collections-research-center/access-our-materials\">Special Collections Research Center</a>, you'll be able to see its record here."

--- a/models/items/interlibrary_loan/past_document_delivery.rb
+++ b/models/items/interlibrary_loan/past_document_delivery.rb
@@ -1,0 +1,25 @@
+class PastDocumentDelivery < InterlibraryLoanItems
+  attr_reader :pagination, :count
+  def initialize(parsed_response:, pagination:, count: nil)
+    super
+    @items = parsed_response.map { |item| PastDocumentDeliveryItem.new(item) }
+    @pagination = pagination
+    @count = count
+  end
+
+
+  private
+  def self.illiad_url(uniqname)
+    "/Transaction/UserRequests/#{uniqname}" 
+  end
+  def self.url
+    "/past-activity/scans-and-electronic-items"
+  end
+  def self.filter
+    "RequestType eq 'Loan' and (TransactionStatus eq 'Request Finished' or startswith(TransactionStatus, 'Cancelled'))"
+  end
+  
+end
+
+class PastDocumentDeliveryItem < InterlibraryLoanItem
+end

--- a/models/items/interlibrary_loan/past_interlibrary_loans.rb
+++ b/models/items/interlibrary_loan/past_interlibrary_loans.rb
@@ -16,7 +16,7 @@ class PastInterlibraryLoans < InterlibraryLoanItems
     "/past-activity/interlibrary-loan"
   end
   def self.filter
-    "TransactionStatus eq 'Request Finished' or startswith(TransactionStatus, 'Cancelled')"
+    "RequestType ne 'Loan' and (TransactionStatus eq 'Request Finished' or startswith(TransactionStatus, 'Cancelled'))"
   end
   
 end

--- a/my_account.rb
+++ b/my_account.rb
@@ -45,6 +45,7 @@ require_relative "./models/items/interlibrary_loan/interlibrary_loan_items"
 require_relative "./models/items/interlibrary_loan/document_delivery"
 require_relative "./models/items/interlibrary_loan/interlibrary_loans"
 require_relative "./models/items/interlibrary_loan/interlibrary_loan_requests"
+require_relative "./models/items/interlibrary_loan/past_document_delivery"
 require_relative "./models/items/interlibrary_loan/past_interlibrary_loans"
 
 
@@ -259,6 +260,12 @@ namespace '/past-activity' do
     session[:past_interlibrary_loans_count] = past_interlibrary_loans.count if session[:past_interlibrary_loans_count].nil? 
 
     erb :past_interlibrary_loans, :locals => { past_interlibrary_loans: past_interlibrary_loans }
+  end
+  get '/scans-and-electronic-items' do
+    past_document_delivery = PastDocumentDelivery.for(uniqname: 'testhelp', limit: params["limit"], offset: params["offset"], count: session[:past_document_delivery_count])
+    session[:past_document_delivery_count] = past_document_delivery.count if session[:past_document_delivery_count].nil? 
+
+    erb :past_document_delivery, :locals => { past_document_delivery: past_document_delivery }
   end
   get '/special-collections' do
     erb :past_special_collections, :locals => { past_special_collections: {} }

--- a/my_account.rb
+++ b/my_account.rb
@@ -256,14 +256,14 @@ namespace '/past-activity' do
   end
 
   get '/interlibrary-loan' do
-    past_interlibrary_loans = PastInterlibraryLoans.for(uniqname: 'testhelp', limit: params["limit"], offset: params["offset"], count: session[:past_interlibrary_loans_count])
-    session[:past_interlibrary_loans_count] = past_interlibrary_loans.count if session[:past_interlibrary_loans_count].nil? 
+    past_interlibrary_loans = PastInterlibraryLoans.for(uniqname: 'testhelp', limit: params["limit"], offset: params["offset"], count: nil)
+    #session[:past_interlibrary_loans_count] = past_interlibrary_loans.count if session[:past_interlibrary_loans_count].nil? 
 
     erb :past_interlibrary_loans, :locals => { past_interlibrary_loans: past_interlibrary_loans }
   end
   get '/scans-and-electronic-items' do
-    past_document_delivery = PastDocumentDelivery.for(uniqname: 'testhelp', limit: params["limit"], offset: params["offset"], count: session[:past_document_delivery_count])
-    session[:past_document_delivery_count] = past_document_delivery.count if session[:past_document_delivery_count].nil? 
+    past_document_delivery = PastDocumentDelivery.for(uniqname: 'testhelp', limit: params["limit"], offset: params["offset"], count: nil)
+    #session[:past_document_delivery_count] = past_document_delivery.count if session[:past_document_delivery_count].nil? 
 
     erb :past_document_delivery, :locals => { past_document_delivery: past_document_delivery }
   end

--- a/my_account.rb
+++ b/my_account.rb
@@ -181,7 +181,7 @@ namespace '/current-checkouts' do
 
     erb :interlibrary_loans, :locals => { interlibrary_loans: interlibrary_loans }
   end
-  get '/document-delivery-or-scans' do
+  get '/scans-and-electronic-items' do
     document_delivery = DocumentDelivery.for(uniqname: 'testhelp')
 
     erb :document_delivery, :locals => { document_delivery: document_delivery }

--- a/spec/models/items/interlibrary_loan/past_document_delivery_spec.rb
+++ b/spec/models/items/interlibrary_loan/past_document_delivery_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 require 'json'
 
-describe PastInterlibraryLoans do
-  let(:query){{"$filter" => "RequestType ne 'Loan' and (TransactionStatus eq 'Request Finished' or startswith(TransactionStatus, 'Cancelled'))", "$top" => '15'}}
+describe PastDocumentDelivery do
+  let(:query){{"$filter" => "RequestType eq 'Loan' and (TransactionStatus eq 'Request Finished' or startswith(TransactionStatus, 'Cancelled'))", "$top" => '15'}}
   context "three loans" do
     before(:each) do
       stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: File.read('./spec/fixtures/illiad_requests.json'), query: query)
     end
     subject do
-      PastInterlibraryLoans.for(uniqname: 'testhelp', count: 25)
+      PastDocumentDelivery.for(uniqname: 'testhelp', count: 25)
     end
     context "#count" do
       it "returns total request item count" do
@@ -21,7 +21,7 @@ describe PastInterlibraryLoans do
         subject.each do |item|
           items = items + item.class.name
         end
-        expect(items).to eq("PastInterlibraryLoan"*5)
+        expect(items).to eq("PastDocumentDeliveryItem"*5)
       end
     end
     context "#empty?" do
@@ -40,7 +40,7 @@ describe PastInterlibraryLoans do
       stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: File.read('./spec/fixtures/illiad_requests.json'), query: {'$filter': query['$filter']})
     end
     subject do
-      PastInterlibraryLoans.for(uniqname: 'testhelp', limit: '1', count: nil)
+      PastDocumentDelivery.for(uniqname: 'testhelp', limit: '1', count: nil)
     end
     context "#count" do
       it "returns total number of transactions" do
@@ -53,7 +53,7 @@ describe PastInterlibraryLoans do
         subject.each do |item|
           items = items + item.class.name
         end
-        expect(items).to eq("PastInterlibraryLoan"*1)
+        expect(items).to eq("PastDocumentDeliveryItem"*1)
       end
     end
   end

--- a/spec/requests_spec.rb
+++ b/spec/requests_spec.rb
@@ -142,12 +142,12 @@ describe "requests" do
       expect(last_response.body).to include("Interlibrary Loan")
     end
   end
-  context "get /current-checkouts/document-delivery-or-scans" do
-    it "contains 'Document Delivery / Scans'" do
+  context "get /current-checkouts/scans-and-electronic-items" do
+    it "contains 'Scans and Electronic Items'" do
       stub_illiad_get_request(url: "Transaction/UserRequests/testhelp", 
         body: File.read("spec/fixtures/illiad_requests.json"))
-      get "/current-checkouts/document-delivery-or-scans" 
-      expect(last_response.body).to include("Document Delivery / Scans")
+      get "/current-checkouts/scans-and-electronic-items" 
+      expect(last_response.body).to include("Scans and Electronic Items")
     end
   end
   context "get /pending-requests" do

--- a/spec/requests_spec.rb
+++ b/spec/requests_spec.rb
@@ -208,11 +208,20 @@ describe "requests" do
   end
   context "get /past-activity/interlibrary-loan" do
     it "contains 'Interlibrary Loan'" do
-      query = {"$filter" => "TransactionStatus eq 'Request Finished' or startswith(TransactionStatus, 'Cancelled')"}
+      query = {"$filter" => "RequestType ne 'Loan' and (TransactionStatus eq 'Request Finished' or startswith(TransactionStatus, 'Cancelled'))"}
       stub_illiad_get_request(url: "Transaction/UserRequests/testhelp", 
         body: File.read("spec/fixtures/illiad_requests.json"), query: query)
       get "/past-activity/interlibrary-loan" 
       expect(last_response.body).to include("Interlibrary Loan")
+    end
+  end
+  context "get /past-activity/scans-and-electronic-items" do
+    it "contains 'Scans and Electronic Items'" do
+      query = {"$filter" => "RequestType eq 'Loan' and (TransactionStatus eq 'Request Finished' or startswith(TransactionStatus, 'Cancelled'))"}
+      stub_illiad_get_request(url: "Transaction/UserRequests/testhelp", 
+        body: File.read("spec/fixtures/illiad_requests.json"), query: query)
+      get "/past-activity/scans-and-electronic-items" 
+      expect(last_response.body).to include("Scans and Electronic Items")
     end
   end
   context "get /past-activity/special-collections" do

--- a/views/past_document_delivery.erb
+++ b/views/past_document_delivery.erb
@@ -1,0 +1,42 @@
+<% if past_document_delivery.count == 0 %>
+
+<%= erb :empty_state %>
+
+<% elsif %>
+
+<div class="table-container">
+<table>
+  <caption>
+    <div class="loan-caption-inner-layout">
+      <p>Showing <strong><%= past_document_delivery.pagination.first %></strong> - <strong><%= past_document_delivery.pagination.last %></strong> of <strong><%= past_document_delivery.count %></strong> <%= past_document_delivery.item_text %></p>
+    </div>
+  </caption>
+  <thead>
+    <tr>
+      <th>Title &amp; author</th>
+      <th style="width: 9rem;">Requested</th>
+      <th style="width: 9rem;">Returned</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% past_document_delivery.each do |past_delivery| %>
+      <tr>
+        <td>
+          
+          <%= erb :title_author, locals: {item: past_delivery} %>
+        </td>
+        <td>
+          <%= past_delivery.creation_date %>
+        </td>
+        <td>
+          <%= past_delivery.transaction_date %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+</div>
+
+<%= erb :pagination, locals: {pagination: past_document_delivery.pagination, count: past_document_delivery.count} %>
+
+<% end %>


### PR DESCRIPTION
# Overview
It has been decided to add [Scans and Electronic Items](http://localhost:4567/past-activity/scans-and-electronic-items) to `Past Activity`. The tab, views, models, and specs have been added. [Past Activity > Interlibrary Loan](http://localhost:4567/past-activity/interlibrary-loan) has been updated to exclude scans and electronic items.

## Problem
Both of the above pages have `.count` and `.last` showing `5`, and I'm not sure why.