### PR TITLE
Drop down changes

### DIFF
--- a/css/_dropdown.scss
+++ b/css/_dropdown.scss
@@ -5,6 +5,15 @@
 
 .dropdown {
   position: relative;
+  @media screen and (max-width: 1000px) {
+    & > .button--dropdown,
+    & .site-navigation-list  {
+      display: none;
+    }
+    & > .dropdown-container {
+      display: block!important
+    }
+  }
 }
 
 .button--dropdown {
@@ -21,14 +30,16 @@
 }
 
 .dropdown-container {
-  background: white;
-  border-radius: 	var(--space-xx-small);
-  box-shadow: var(--z-space-medium);
-  padding: var(--space-medium) var(--space-large);
-  position: absolute;
-  right: 0;
-  top: 100%;
-  z-index: 101;
+  @media screen and (min-width: 1001px) {
+    background: white;
+    border-radius: 	var(--space-xx-small);
+    box-shadow: var(--z-space-medium);
+    padding: var(--space-medium) var(--space-large);
+    position: absolute;
+    right: 0;
+    top: 100%;
+    z-index: 101;
+  }
   ul,
   li {
     margin: 0;
@@ -36,10 +47,12 @@
   }
   ul {
     list-style: none;
-    & + ul {
-      border-top: solid 1px var(--color-neutral-100);
-      margin-top: var(--space-xx-small);
-      padding-top: var(--space-xx-small);
+    @media screen and (min-width: 1001px) {
+      & + ul {
+        border-top: solid 1px var(--color-neutral-100);
+        margin-top: var(--space-xx-small);
+        padding-top: var(--space-xx-small);
+      }
     }
   }
   a {

--- a/js/index.js
+++ b/js/index.js
@@ -84,9 +84,11 @@
     const getID = dropdown.getAttribute('data-dropdown');
     const getDropdown = document.getElementById(getID);
     let getAriaExpanded = dropdown.getAttribute('aria-expanded');
+    // Convert value to boolean
+    getAriaExpanded = getAriaExpanded === true;
     dropdown.addEventListener('click', (event) => {
       // Toggle `aria-expanded` as true or false
-      getAriaExpanded = getAriaExpanded !== true;
+      getAriaExpanded = !getAriaExpanded;
       event.target.setAttribute('aria-expanded', getAriaExpanded);
       // Toggle display for dropdown
       getDropdown.style.display = getAriaExpanded ? 'block' : 'none';
@@ -109,8 +111,8 @@
     });
     window.addEventListener('resize', (event) => {
       if (
-        (window.innerWidth <= breakpoint && getAriaExpanded !== true) ||
-        (window.innerWidth > breakpoint && getAriaExpanded === true)
+        (window.innerWidth <= breakpoint && !getAriaExpanded) ||
+        (window.innerWidth > breakpoint && getAriaExpanded)
       ) {
         dropdown.click();
       }

--- a/js/index.js
+++ b/js/index.js
@@ -92,9 +92,16 @@
       // Toggle arrow up or down
       dropdown.children[2].setAttribute('name', getAriaExpanded ? 'keyboard-arrow-up' : 'keyboard-arrow-down');
     });
-    [dropdown, getDropdown].forEach((element) => {
-      element.addEventListener('keyup', (event) => {
-        if (event.key === 'Escape') {
+    // Close dropdown if `Escape` has been pressed or clicked outside of dropdown
+    ['click', 'keyup'].forEach((listener) => {
+      document.addEventListener(listener, (event) => {
+        if (
+          getAriaExpanded === true &&
+          (
+            (listener === 'click' && event.target !== dropdown) ||
+            event.key === 'Escape'
+          )
+        ) {
           dropdown.click();
         }
       });

--- a/js/index.js
+++ b/js/index.js
@@ -78,6 +78,7 @@
  * Dropdown Menu
  */
 (function () {
+  const breakpoint = 1000;
   const dropdowns = document.querySelectorAll('[data-dropdown]');
   dropdowns.forEach((dropdown) => {
     const getID = dropdown.getAttribute('data-dropdown');
@@ -106,5 +107,14 @@
         }
       });
     });
+    window.addEventListener('resize', (event) => {
+      if (
+        (window.innerWidth <= breakpoint && getAriaExpanded !== true) ||
+        (window.innerWidth > breakpoint && getAriaExpanded === true)
+      ) {
+        dropdown.click();
+      }
+    });
+    window.dispatchEvent(new Event('resize'));
   });
 })();


### PR DESCRIPTION
# Overview
This PR resolves two requests to the user dropdown menu:
* > REMOVE user drop-down and replace with Log out
* Close the drop-down if clicking outside of the menu.

Styling has been added so everything else will hide, except the `Log out` list item when viewing the smaller breakpoint.