### PR TITLE
Back to Account Overview

### DIFF
--- a/css/_horizontal-navigation.scss
+++ b/css/_horizontal-navigation.scss
@@ -1,3 +1,9 @@
+.breadcrumbs {
+  @media screen and (min-width: 1001px) {
+    display: none;
+  }
+}
+
 .horizontal-navigation-container {
   display: flex;
   flex-direction: column;

--- a/css/_site-navigation.scss
+++ b/css/_site-navigation.scss
@@ -1,4 +1,10 @@
 .site-navigation {
+  @media screen and (max-width: 1000px) {
+    display: none;
+    & + .site-layout__center {
+      grid-column: 1 / 3;
+    }
+  }
   ul {
     list-style: none;
     padding: 0;

--- a/lib/navigation.rb
+++ b/lib/navigation.rb
@@ -20,6 +20,9 @@ class Navigation
   def title
     @pages.detect{|page| page.active? }.title
   end
+  def home
+    @pages[0].title
+  end
 end
 class Page
   attr_reader :title, :description, :icon_name, :color, :children, :empty_state

--- a/views/horizontal_nav.erb
+++ b/views/horizontal_nav.erb
@@ -3,6 +3,11 @@
   horizontal_nav = nav.horizontal_nav
 %>
 
+<p class="breadcrumbs">
+  <m-icon name="keyboard-arrow-left"></m-icon>
+  <a href="/">Back to <%=nav.home%></a>
+</p>
+
 <% if horizontal_nav.nil?%>
 
   <h1><%=nav.title%></h1>

--- a/views/horizontal_nav.erb
+++ b/views/horizontal_nav.erb
@@ -3,10 +3,12 @@
   horizontal_nav = nav.horizontal_nav
 %>
 
-<p class="breadcrumbs">
-  <m-icon name="keyboard-arrow-left"></m-icon>
-  <a href="/">Back to <%=nav.home%></a>
-</p>
+<% if nav.home != nav.title %>
+  <p class="breadcrumbs">
+    <m-icon name="keyboard-arrow-left"></m-icon>
+    <a href="/">Back to <%=nav.home%></a>
+  </p>
+<% end %>
 
 <% if horizontal_nav.nil?%>
 


### PR DESCRIPTION
# Overview
This pull request resolves these two requests:
* > At small screen breakpoint, drop side navigation instead of stacking below header
* > At small screen breakpoint, add breadcrumb between header and title to all pages except the Account overview with: < Back to Account Overview 