### PR TITLE
Fixing horizontal scroll

### DIFF
--- a/views/document_delivery.erb
+++ b/views/document_delivery.erb
@@ -15,7 +15,7 @@
     <tr>
       <th>Title & author</th>
       <th style="width: 9rem;">Due date</th>
-      <th style="width: 5rem;">Action</th>
+      <th style="width: 6rem;">Action</th>
     </tr>
   </thead>
   <tbody>

--- a/views/interlibrary_loans.erb
+++ b/views/interlibrary_loans.erb
@@ -15,7 +15,7 @@
     <tr>
       <th>Title &amp; author</th>
       <th style="width: 9rem;">Due date</th>
-      <th style="width: 5rem;">Action</th>
+      <th style="width: 6rem;">Action</th>
     </tr>
   </thead>
   <tbody>

--- a/views/shelf.erb
+++ b/views/shelf.erb
@@ -44,7 +44,7 @@
     <tr>
       <th>Title & author</th>
       <th style="width: 9rem;">Due date</th>
-      <th style="width: 5rem;">Action</th>
+      <th style="width: 6rem;">Action</th>
     </tr>
   </thead>
 


### PR DESCRIPTION
# Overview
This pull request resolves this request:
* > In Safari, checkout list viewport scrolls right/left on a desktop

The `Action` column needed to be lengthened because the button went beyond `5rem`.