### PR TITLE
Current Checkouts - Document Delivery: Expires Date

### DIFF
--- a/views/document_delivery.erb
+++ b/views/document_delivery.erb
@@ -14,7 +14,7 @@
   <thead>
     <tr>
       <th>Title & author</th>
-      <th style="width: 9rem;">Due date</th>
+      <th style="width: 9rem;">Expires</th>
       <th style="width: 6rem;">Action</th>
     </tr>
   </thead>


### PR DESCRIPTION
# Overview
Updated `Due Date` to `Expires` ([see mockup](https://projects.invisionapp.com/d/main/default/#/console/20707215/443036072/preview) to confirm label). Date does not currently show because there isn't an existing example with a date.

Resolves #74 