### PR TITLE
Circ History and Not-in-Alma

### DIFF
--- a/lib/empty_state.rb
+++ b/lib/empty_state.rb
@@ -23,7 +23,7 @@ class EmptyState
     if current_parent.empty_state
       empty_state = current_parent.empty_state["#{prop}"] || empty_state
     end
-    if !current_parent.children.nil? && current_parent.children.find{|page| page.active? }.empty_state
+    if current_parent&.children&.find{|page| page.active? }&.empty_state
       empty_state = current_parent.children.find{|page| page.active? }.empty_state["#{prop}"] || empty_state
     end
     empty_state

--- a/my_account.rb
+++ b/my_account.rb
@@ -73,8 +73,9 @@ get '/auth/openid_connect/callback' do
   auth = request.env['omniauth.auth']
   info = auth[:info]
   session[:authenticated] = true
-  session[:uniqname] = info[:nickname]
   session[:expires_at] = Time.now.utc + auth.credentials.expires_in
+  patron = SessionPatron.new(info[:nickname])
+  patron.to_h.each{|k,v| session[k] = v}
   redirect '/'
 end
 
@@ -286,6 +287,7 @@ namespace '/settings' do
   post '/history' do
     response = Patron.set_retain_history(uniqname: session[:uniqname], retain_history: params[:retain_history])
     if response.code == 200
+      session[:confirmed_history_setting] = true      
       flash[:success] = "<strong>Success:</strong> History Setting Successfully Changed"
     else
       flash[:error] = "<strong>Error:</strong> #{response.message}"

--- a/my_account.rb
+++ b/my_account.rb
@@ -161,10 +161,14 @@ namespace '/current-checkouts' do
   end
 
   get '/u-m-library' do
-    loan_controls = TableControls::LoansForm.new(limit: params["limit"], order_by: params["order_by"], direction: params["direction"])
-    loans = Loans.for(uniqname: session[:uniqname], offset: params["offset"], limit: params["limit"], order_by: params["order_by"], direction: params["direction"])
-    message = session.delete(:message)
-    erb :shelf, :locals => { loans: loans, message: message, loan_controls: loan_controls, has_js: true}
+    if session[:in_alma]
+      loan_controls = TableControls::LoansForm.new(limit: params["limit"], order_by: params["order_by"], direction: params["direction"])
+      loans = Loans.for(uniqname: session[:uniqname], offset: params["offset"], limit: params["limit"], order_by: params["order_by"], direction: params["direction"])
+      message = session.delete(:message)
+      erb :shelf, :locals => { loans: loans, message: message, loan_controls: loan_controls, has_js: true}
+    else
+      erb :empty_state
+    end
   end
   
   post '/u-m-library' do
@@ -199,9 +203,13 @@ namespace '/pending-requests' do
   end
 
   get '/u-m-library' do
-    requests = Requests.for(uniqname: session[:uniqname])
+    if session[:in_alma]
+      requests = Requests.for(uniqname: session[:uniqname])
 
-    erb :requests, :locals => { holds: requests.holds, bookings: requests.bookings }
+      erb :requests, :locals => { holds: requests.holds, bookings: requests.bookings }
+    else
+      erb :empty_state
+    end
   end
   post '/u-m-library/cancel-request' do
     response = Request.cancel(uniqname: session[:uniqname], request_id: params["request_id"])
@@ -238,9 +246,13 @@ namespace '/past-activity' do
 
   namespace '/u-m-library' do
     get '' do
-      table_controls = TableControls::PastLoansForm.new(limit: params["limit"], order_by: params["order_by"], direction: params["direction"])
-      past_loans = CirculationHistoryItems.for(uniqname: session[:uniqname], offset: params["offset"], limit: params["limit"], order_by: params["order_by"], direction: params["direction"])
-      erb :past_loans, :locals => {past_loans: past_loans, table_controls: table_controls}
+      if session[:in_alma]
+        table_controls = TableControls::PastLoansForm.new(limit: params["limit"], order_by: params["order_by"], direction: params["direction"])
+        past_loans = CirculationHistoryItems.for(uniqname: session[:uniqname], offset: params["offset"], limit: params["limit"], order_by: params["order_by"], direction: params["direction"])
+        erb :past_loans, :locals => {past_loans: past_loans, table_controls: table_controls}
+      else
+        erb :empty_state
+      end
     end
     get '/download.csv' do
       resp = CircHistoryClient.new(session[:uniqname]).download_csv
@@ -326,8 +338,12 @@ end
 
 namespace '/fines-and-fees' do
   get '' do
-    fines = Fines.for(uniqname: session[:uniqname])
-    erb :fines, :locals => { fines: fines }
+    if session[:in_alma]
+      fines = Fines.for(uniqname: session[:uniqname])
+      erb :fines, :locals => { fines: fines }
+    else
+      erb :empty_state
+    end
   end
 
   

--- a/spec/models/patron_spec.rb
+++ b/spec/models/patron_spec.rb
@@ -196,7 +196,7 @@ describe Patron do
       end
     end
   end
-  context "nonexistent uniqname" do
+  context "nonexistent uniqname and not in circ history" do
     before(:each) do
       @alma_response = File.read('./spec/fixtures/alma_error.json')
       @patron_url = "users/mrioaaa?user_id_type=all_unique&view=full&expand=none"
@@ -207,6 +207,7 @@ describe Patron do
       )
       stub_circ_history_get_request(
         url: 'users/mrioaaa',
+        status: 400
       )
     end
     subject do

--- a/spec/requests_spec.rb
+++ b/spec/requests_spec.rb
@@ -13,6 +13,10 @@ describe "requests" do
     }
     env 'rack.session', @session
   end
+  let(:not_in_alma) do
+    @session[:in_alma] = false
+    env 'rack.session', @session
+  end
 
   context "get '/auth/openid_connect/callback'" do
     let(:omniauth_auth) {
@@ -84,16 +88,25 @@ describe "requests" do
     end
   end
   context "get /current-checkouts/u-m-library" do
-    before(:each) do
-      stub_alma_get_request(url: "users/tutor/loans", query: {expand: 'renewable', limit: 15, order_by: "due_date"})
+    context "in alma user" do
+      before(:each) do
+        stub_alma_get_request(url: "users/tutor/loans", query: {expand: 'renewable', limit: 15, order_by: "due_date"})
+      end
+      it "contains 'U-M Library'" do
+        get "/current-checkouts/u-m-library"
+        expect(last_response.body).to include("U-M Library")
+      end
+      it "has checkouts js" do
+        get "/current-checkouts/u-m-library"
+        expect(last_response.body).to include("current-checkouts-u-m-library.bundle.js")
+      end
     end
-    it "contains 'U-M Library'" do
-      get "/current-checkouts/u-m-library"
-      expect(last_response.body).to include("U-M Library")
-    end
-    it "has checkouts js" do
-      get "/current-checkouts/u-m-library"
-      expect(last_response.body).to include("current-checkouts-u-m-library.bundle.js")
+    context "not in alma user" do
+      it "has empty checkouts" do
+        not_in_alma
+        get "/current-checkouts/u-m-library"
+        expect(last_response.body).to include("You don't have")
+      end
     end
   end
   context "post /current-checkouts/u-m-library" do
@@ -170,10 +183,19 @@ describe "requests" do
     end
   end
   context "get /pending-requests/u-m-library" do
-    it "contains 'U-M Library'" do
-      stub_alma_get_request(url: "users/tutor/requests", body: File.read("./spec/fixtures/requests.json"), query: {limit: 100, offset: 0}  )
-      get "/pending-requests/u-m-library"
-      expect(last_response.body).to include("U-M Library")
+    context "in alma" do
+      it "contains 'U-M Library'" do
+        stub_alma_get_request(url: "users/tutor/requests", body: File.read("./spec/fixtures/requests.json"), query: {limit: 100, offset: 0}  )
+        get "/pending-requests/u-m-library"
+        expect(last_response.body).to include("U-M Library")
+      end
+    end
+    context "not in alma" do
+      it "shows empty sate pending requests" do
+        not_in_alma
+        get "/pending-requests/u-m-library"
+        expect(last_response.body).to include("You don't have")
+      end
     end
   end
   context "get /pending-requests/interlibrary-loan" do
@@ -205,10 +227,19 @@ describe "requests" do
     end
   end
   context "get /past-activity/u-m-library" do
-    it "exists" do
-      stub_circ_history_get_request(url: "users/tutor/loans")
-      get "/past-activity/u-m-library" 
-      expect(last_response.status).to eq(200)
+    context "in alma user" do
+      it "exists" do
+        stub_circ_history_get_request(url: "users/tutor/loans")
+        get "/past-activity/u-m-library" 
+        expect(last_response.status).to eq(200)
+      end
+    end
+    context "not in alma user" do
+      it "show do not have circ history" do
+        not_in_alma
+        get "/past-activity/u-m-library" 
+        expect(last_response.body).to include("You don't have")
+      end
     end
   end
   context "get /past-activity/interlibrary-loan" do
@@ -236,11 +267,20 @@ describe "requests" do
     end
   end
   context "get /fines-and-fees" do
-    it "contains 'Fines'" do
-      stub_alma_get_request(url: "users/tutor/fees", query: {limit: 100, offset: 0}, 
-        body: File.read("spec/fixtures/jbister_fines.json"))
-      get "/fines-and-fees"
-      expect(last_response.body).to include("Fines")
+    context "in alma user" do
+      it "contains 'Fines'" do
+        stub_alma_get_request(url: "users/tutor/fees", query: {limit: 100, offset: 0}, 
+          body: File.read("spec/fixtures/jbister_fines.json"))
+        get "/fines-and-fees"
+        expect(last_response.body).to include("Fines")
+      end
+    end
+    context "not in alma user" do
+      it "show do not have fines and fees" do
+        not_in_alma
+        get "/fines-and-fees"
+        expect(last_response.body).to include("You don't have")
+      end
     end
   end
   context "get /favorites" do

--- a/views/development_users.erb
+++ b/views/development_users.erb
@@ -10,6 +10,10 @@
     {
       label: "New student (none)",
       value: 'mlibrary.acct.testing3@gmail.com'
+    },
+    {
+      label: 'Not in Alma',
+      value: 'definitelynotinalma'
     }
   ]
 %>

--- a/views/patron.erb
+++ b/views/patron.erb
@@ -1,51 +1,52 @@
 <div class="owl narrow-content">
+  <% if patron.in_alma? %>
+    <p>You can update your name and address at <a href="https://wolverineaccess.umich.edu/task/all/campus-personal-info">Wolverine Access</a>.</p>
 
-  <p>You can update your name and address at <a href="https://wolverineaccess.umich.edu/task/all/campus-personal-info">Wolverine Access</a>.</p>
+    <p>To change document delivery preferences, visit your <a href="https://ill.lib.umich.edu/illiad/ChangeSite/ChangeSite.asp">interlibrary loan account</a>.</p>
 
-  <p>To change document delivery preferences, visit your <a href="https://ill.lib.umich.edu/illiad/ChangeSite/ChangeSite.asp">interlibrary loan account</a>.</p>
+    <table class="patron-table">
+      <tr>
+        <th>Full name</th>
+        <td><%= patron.full_name %></td>
+      </tr>
+      <tr>
+        <th>Email</th>
+        <td><%= patron.email_address %></td>
+      </tr>
+    </table>
 
-  <table class="patron-table">
-    <tr>
-      <th>Full name</th>
-      <td><%= patron.full_name %></td>
-    </tr>
-    <tr>
-      <th>Email</th>
-      <td><%= patron.email_address %></td>
-    </tr>
-  </table>
+    <form class="owl" method="post" action="/sms">
+      <h2>Text Notifications</h2>
 
-  <form class="owl" method="post" action="/sms">
-    <h2>Text Notifications</h2>
+      <p>Add a phone number to receive text notifications on the status of your request and loans. Special collections requests are not included. Message and data rates may apply.</p>
 
-    <p>Add a phone number to receive text notifications on the status of your request and loans. Special collections requests are not included. Message and data rates may apply.</p>
-
-    <input type="checkbox" class="toggle-switch visually-hidden" id="text-notifications" name="text-notifications" <% if patron.sms_number? %>checked<% end%>>
-    <label class="toggle-switch-label" for="text-notifications">
-      <div class="toggle"></div>
-      <span>You wish to receive text notifications</span>
-    </label>
-
-    <div class="sms-number-container">
-      <label class="text-notifications-label" for="sms-number">
-        Phone number
+      <input type="checkbox" class="toggle-switch visually-hidden" id="text-notifications" name="text-notifications" <% if patron.sms_number? %>checked<% end%>>
+      <label class="toggle-switch-label" for="text-notifications">
+        <div class="toggle"></div>
+        <span>You wish to receive text notifications</span>
       </label>
-      <input
-        type="tel"
-        name="sms-number"
-        id="sms-number"
-        value="<%= patron.sms_number %>"
-        pattern="\(\d{3}\) \d{3}-\d{4}"
-        aria-describedby="sms-number-description"
-        autocomplete="on"
-      />
-      <div id="sms-number-description">
-        <m-icon name="info"></m-icon><span class="input-description">Phone number must be 10 digits. Example: (123) 456-7890.</span>
-      </div>
-    </div>
 
-    <button>Update notification preferences</button>
-  </form>
+      <div class="sms-number-container">
+        <label class="text-notifications-label" for="sms-number">
+          Phone number
+        </label>
+        <input
+          type="tel"
+          name="sms-number"
+          id="sms-number"
+          value="<%= patron.sms_number %>"
+          pattern="\(\d{3}\) \d{3}-\d{4}"
+          aria-describedby="sms-number-description"
+          autocomplete="on"
+        />
+        <div id="sms-number-description">
+          <m-icon name="info"></m-icon><span class="input-description">Phone number must be 10 digits. Example: (123) 456-7890.</span>
+        </div>
+      </div>
+
+      <button>Update notification preferences</button>
+    </form>
+  <% end %>
 
   <form class="owl" method="post" action="/settings/history">
     <h2>Checkout History</h2>


### PR DESCRIPTION
Banner updates properly for when updating circ history setting.
Empty states applied for U-M data if user is not in Alma. 