### PR TITLE
Add horizontal navigation stacking design for small screens.

### DIFF
--- a/css/_horizontal-navigation.scss
+++ b/css/_horizontal-navigation.scss
@@ -12,9 +12,27 @@
     list-style: none;
     margin: 0;
     border-bottom: solid 1px var(--color-neutral-100);
+
+    @media screen and (max-width: 1000px) {
+      background: var(--color-blue-100);
+      margin: 0 calc(-1 * var(--space-medium));
+    }
   
     li {
-      display: inline-block;
+      @media screen and (min-width: 1001px) {
+        display: inline-block;
+      }
+
+      @media screen and (max-width: 1000px) {
+        &:first-of-type {
+          border-top: solid 1px var(--color-neutral-100);
+        }
+
+        &:not(:last-child) {
+          border-bottom: solid 1px var(--color-neutral-100);
+        }
+      }
+
       margin-bottom: 0;
     }
   
@@ -29,16 +47,32 @@
       text-decoration: none;
       color: var(--color-neutral-400);
       font-weight: 600;
+
+      @media screen and (max-width: 1000px) {
+        padding: var(--space-medium);
+      }
   
-      &:not(.active):hover {
+      &:hover {
         text-decoration: underline;
         text-decoration-thickness: 2px;
       }
     }
   
-    a.active {
+    a.active, a[aria-current="page"] {
       color: var(--color-teal-400);
-      border-bottom: 4px solid var(--color-teal-400);
+      font-weight: 800;
+
+      @media screen and (min-width: 999px) {
+        display: inline-block;
+        border: 0;
+        border-bottom: 4px solid var(--color-teal-400);
+      }
+
+      @media screen and (max-width: 1000px) {
+        border: 0;
+        border-left: 4px solid var(--color-teal-400);
+        padding-left: calc(var(--space-medium) - 4px); // less the width of the border.
+      }
     }
   }
   

--- a/css/_horizontal-navigation.scss
+++ b/css/_horizontal-navigation.scss
@@ -41,7 +41,7 @@
     }
   
     a {
-      display: inline-block;
+      display: block;
       padding: var(--space-medium) 0;
       margin-bottom: -1px;
       text-decoration: none;

--- a/css/_horizontal-navigation.scss
+++ b/css/_horizontal-navigation.scss
@@ -56,22 +56,21 @@
         text-decoration: underline;
         text-decoration-thickness: 2px;
       }
-    }
+
+      &[aria-current="page"] {
+        border: 0;
+        color: var(--color-teal-400);
+        font-weight: 800;
   
-    a.active, a[aria-current="page"] {
-      color: var(--color-teal-400);
-      font-weight: 800;
-
-      @media screen and (min-width: 999px) {
-        display: inline-block;
-        border: 0;
-        border-bottom: 4px solid var(--color-teal-400);
-      }
-
-      @media screen and (max-width: 1000px) {
-        border: 0;
-        border-left: 4px solid var(--color-teal-400);
-        padding-left: calc(var(--space-medium) - 4px); // less the width of the border.
+        @media screen and (min-width: 1001px) {
+          display: inline-block;
+          border-bottom: 4px solid var(--color-teal-400);
+        }
+  
+        @media screen and (max-width: 1000px) {
+          border-left: 4px solid var(--color-teal-400);
+          padding-left: calc(var(--space-medium) - 4px); // less the width of the border.
+        }
       }
     }
   }

--- a/views/horizontal_nav.erb
+++ b/views/horizontal_nav.erb
@@ -25,7 +25,7 @@
     <ul class="horizontal-navigation-list">
         <% horizontal_nav.children.each do |child| %>
           <li>
-            <a href="<%=child.path%>" <%= child.active? ? 'aria-current="page"' : '' ; %>>
+            <a href="<%=child.path%>"  <% if child.active? %>aria-current="page"<% end %>>
               <%=child.title%>
             </a>
           </li>

--- a/views/horizontal_nav.erb
+++ b/views/horizontal_nav.erb
@@ -25,7 +25,7 @@
     <ul class="horizontal-navigation-list">
         <% horizontal_nav.children.each do |child| %>
           <li>
-            <a href="<%=child.path%>" class="<%=child.active%>" >
+            <a href="<%=child.path%>" <%= child.active? ? 'aria-current="page"' : '' ; %>>
               <%=child.title%>
             </a>
           </li>

--- a/views/navigation.erb
+++ b/views/navigation.erb
@@ -5,7 +5,7 @@
     <ul class="site-navigation-list">
       <% my_pages.pages.each do |page| %>
         <li class="<%= page.active %>">
-          <a href="<%=page.path%>">
+          <a href="<%=page.path%>" <% if page.active? %>aria-current="page"<% end %>>
             <m-icon name="<%=page.icon_name%>"></m-icon><span><%=page.title%></span>
           </a>
         </li>

--- a/views/user_drop_down.erb
+++ b/views/user_drop_down.erb
@@ -10,7 +10,7 @@
     <ul class="site-navigation-list">
       <% dropdown.pages.each do |page| %>
         <li class="<%= page.active %>">
-          <a href="<%=page.path%>">
+          <a href="<%=page.path%>" <% if page.active? %>aria-current="page"<% end %>>
             <span><%=page.title%></span>
           </a>
         </li>


### PR DESCRIPTION
## What's new?

This adds specific CSS for horizontal navigation to stack vertically (should this be called "page navigation?") when the viewport is less than 1000px.

## Preview

<img width="1414" alt="Screen Shot 2021-06-25 at 9 24 29 AM" src="https://user-images.githubusercontent.com/1678665/123431453-450a1a00-d597-11eb-855d-2b5b5f6e08eb.png">
