### PR TITLE
Fixing banner height from grid sizes

### DIFF
--- a/css/_base.scss
+++ b/css/_base.scss
@@ -40,12 +40,8 @@ body {
   height: 100%;
 }
 body {
-  display: grid;
-  grid-template-rows: auto auto 1fr auto;
-  @media screen and (min-width: 820px) {
-    grid-template-rows: auto auto 1fr auto;
-  }
-  grid-template-columns: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 main.layout {


### PR DESCRIPTION
# Overview
`display: grid` on the `body` and the defined grid columns made `.banner` stretch in height. The `display` was changed to `flex` to resolve this bug.