### PR TITLE
Horizontal nav breakpoints

### DIFF
--- a/css/_base.scss
+++ b/css/_base.scss
@@ -83,7 +83,7 @@ h4 {
 
 .layout {
   padding: 0 var(--space-medium);
-  max-width: 1280px;
+  max-width: $desktop;
   margin: 0 auto;
 
   @media screen and ($breakpoint-medium) {

--- a/css/_breakpoints.scss
+++ b/css/_breakpoints.scss
@@ -1,3 +1,6 @@
-$breakpoint-small: 'max-width: 1000px';
-$breakpoint-medium: 'min-width: 1001px';
-$breakpoint-large: 'min-width: 1280px';
+$mobile: 1000px;
+$desktop: 1280px;
+
+$breakpoint-small: 'max-width: #{$mobile}';
+$breakpoint-medium: 'min-width: #{$mobile + 1}';
+$breakpoint-large: 'min-width: #{$desktop}';

--- a/css/_horizontal-navigation.scss
+++ b/css/_horizontal-navigation.scss
@@ -50,15 +50,24 @@
       }
 
       &[aria-current="page"] {
-        border-left: var(--space-xx-small) solid var(--color-teal-400);
         color: var(--color-teal-400);
         font-weight: 800;
-        padding-left: calc(var(--space-medium) - var(--space-xx-small)); // less the width of the border.
-        
-        @media screen and ($breakpoint-large) {
-          border: 0;
-          border-bottom: var(--space-xx-small) solid var(--color-teal-400);
-          padding-left: 0;
+        position: relative;
+
+        &::before {
+          background-color: var(--color-teal-400);
+          content: '';
+          height: 100%;
+          left: 0;
+          position: absolute;
+          top: 0;
+          width: var(--space-xx-small);
+          @media screen and ($breakpoint-large) {
+            bottom: 0;
+            height: var(--space-xx-small);
+            top: auto;
+            width: 100%;
+          }
         }
       }
     }

--- a/css/_horizontal-navigation.scss
+++ b/css/_horizontal-navigation.scss
@@ -9,47 +9,39 @@
   flex-direction: column;
 
   .horizontal-navigation-list {
-    list-style: none;
-    margin: 0;
+    background: var(--color-blue-100);
     border-bottom: solid 1px var(--color-neutral-100);
-
-    @media screen and ($breakpoint-small) {
-      background: var(--color-blue-100);
-      margin: 0 calc(-1 * var(--space-medium));
+    list-style: none;
+    margin: 0 calc(-1 * var(--space-medium));
+    
+    @media screen and ($breakpoint-large) {
+      background-color: transparent;
+      margin: 0;
     }
   
     li {
-      @media screen and ($breakpoint-medium) {
-        display: inline-block;
-      }
-
-      @media screen and ($breakpoint-small) {
-        &:first-of-type {
-          border-top: solid 1px var(--color-neutral-100);
-        }
-
-        &:not(:last-child) {
-          border-bottom: solid 1px var(--color-neutral-100);
-        }
-      }
-
+      border-top: solid 1px var(--color-neutral-100);
       margin-bottom: 0;
-    }
-  
-    li:not(:last-of-type) {
-      padding-right: var(--space-large);
+
+      @media screen and ($breakpoint-large) {
+        border-top: 0;
+        display: inline-block;
+        & + li {
+          padding-left: var(--space-large);
+        }
+      }
     }
   
     a {
-      display: block;
-      padding: var(--space-medium) 0;
-      margin-bottom: -1px;
-      text-decoration: none;
       color: var(--color-neutral-400);
+      display: block;
       font-weight: 600;
+      margin-bottom: -1px;
+      padding: var(--space-medium);
+      text-decoration: none;
 
-      @media screen and ($breakpoint-small) {
-        padding: var(--space-medium);
+      @media screen and ($breakpoint-large) {
+        padding: var(--space-medium) 0;
       }
   
       &:hover {
@@ -58,26 +50,23 @@
       }
 
       &[aria-current="page"] {
-        border: 0;
+        border-left: var(--space-xx-small) solid var(--color-teal-400);
         color: var(--color-teal-400);
         font-weight: 800;
-  
-        @media screen and ($breakpoint-medium) {
-          display: inline-block;
-          border-bottom: 4px solid var(--color-teal-400);
-        }
-  
-        @media screen and ($breakpoint-small) {
-          border-left: 4px solid var(--color-teal-400);
-          padding-left: calc(var(--space-medium) - 4px); // less the width of the border.
+        padding-left: calc(var(--space-medium) - var(--space-xx-small)); // less the width of the border.
+        
+        @media screen and ($breakpoint-large) {
+          border: 0;
+          border-bottom: var(--space-xx-small) solid var(--color-teal-400);
+          padding-left: 0;
         }
       }
     }
   }
   
   .horizontal-heading {
-    margin-top: var(--space-xx-large);
     margin-bottom: var(--space-small);
+    margin-top: var(--space-xx-large);
     order: 2;
   }
 }

--- a/css/_utilities.scss
+++ b/css/_utilities.scss
@@ -1,5 +1,5 @@
 .prose {
-  @media screen and ($breakpoint-medium) {
+  @media screen and ($breakpoint-large) {
     font-size: var(--text-x-small);
   }
 


### PR DESCRIPTION
# Overview
The horizontal navigation in `Past Activity` has a very wide navigation and starts wrapping before the small breakpoint. This PR converts the navigation to the stacked version when reaching the large breakpoint.

## Testing
* Run `npm run build-css`
* Check all pages with horizontal navigations and play around with the browser width. Make sure nothing is broken.