### PR TITLE
Adding meta tags with descriptions

### DIFF
--- a/config/navigation.json
+++ b/config/navigation.json
@@ -1,6 +1,7 @@
 [
   { 
     "title": "Account Overview",
+    "description": "Providing access to all of your current account information, including your checkouts and all of your requests for materials (including interlibrary loan and special collection requests).",
     "icon_name": "home",
     "dropdown": "true"
   },

--- a/lib/navigation/description.rb
+++ b/lib/navigation/description.rb
@@ -2,13 +2,16 @@ class Navigation::Description < Navigation
   def initialize(page)
     @page = page
   end
-  def to_s
+  def text
     if @page.description
-      description = @page.description
+      @page.description
     elsif @page.parent&.description
-      description = @page.parent.description
+      @page.parent.description
     else
-      description = Entities::Pages.all[0].description
+      Entities::Pages.all[0].description
     end
+  end
+  def to_s
+    self.text
   end
 end

--- a/lib/navigation/description.rb
+++ b/lib/navigation/description.rb
@@ -1,0 +1,14 @@
+class Navigation::Description < Navigation
+  def initialize(page)
+    @page = page
+  end
+  def to_s
+    if @page.description
+      description = @page.description
+    elsif @page.parent&.description
+      description = @page.parent.description
+    else
+      description = Entities::Pages.all[0].description
+    end
+  end
+end

--- a/lib/navigation/page.rb
+++ b/lib/navigation/page.rb
@@ -1,7 +1,7 @@
 class Navigation
   class Page
     extend Forwardable
-    def_delegators :@page, :title, :path, :icon_name
+    def_delegators :@page, :title, :description, :path, :icon_name
     def initialize(page)
       @page = page
     end

--- a/my_account.rb
+++ b/my_account.rb
@@ -20,6 +20,7 @@ require_relative "./lib/navigation/horizontal_nav"
 require_relative "./lib/navigation/sidebar"
 require_relative "./lib/navigation/user_dropdown"
 require_relative "./lib/navigation/title"
+require_relative "./lib/navigation/description"
 
 require_relative "./lib/utility"
 require_relative "./lib/illiad_client"

--- a/spec/lib/navigation/description_spec.rb
+++ b/spec/lib/navigation/description_spec.rb
@@ -1,0 +1,12 @@
+describe Navigation::Description do
+  context "description for current page" do
+    it "pulls in the page's description" do
+      expect(described_class.for('/').to_s).to eq('Providing access to all of your current account information, including your checkouts and all of your requests for materials (including interlibrary loan and special collection requests).')
+    end
+  end
+  context "description from parent page" do
+    it "pulls in the parent page's description if current page does not have a description" do
+      expect(described_class.for('/current-checkouts/u-m-library').to_s).to eq("View items you've checked out and see when they're due.")
+    end
+  end
+end

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -41,12 +41,12 @@
     <link rel="apple-touch-icon" href="/icon-180x180.png">
     <link rel="manifest" href="/manifest.webmanifest">
 
-    <meta property="og:title" content="<%= title %>" />
+    <meta property="og:title" content="<%= title %> | University of Michigan Library" />
     <meta property="og:description" content="<%= description %>" />
     <meta property="og:image" content="https://account.lib.umich.edu/icon-512x512.png" />
     <meta property="og:image:alt" content="University of Michigan's Block M" />
     <meta property="og:url" content="https://account.lib.umich.edu/"/>
-    <meta property="og:site_name" content="Erin E. Sullivan" />
+    <meta property="og:site_name" content="My Account" />
 
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@umichlibrary">

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -29,10 +29,29 @@
       title = Navigation::Title.for(request.path_info)
     %>
     <title><%= title %> | University of Michigan Library</title>
+    <%
+      description = Navigation::Description.for(request.path_info)
+    %>
+    <meta name="description" content="<%= description %>"/>
+
+    <meta name="theme-color" content="#ffcb05"/>
+
     <link rel="icon" href="/favicon.ico">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon-180x180.png">
     <link rel="manifest" href="/manifest.webmanifest">
+
+    <meta property="og:title" content="<%= title %>" />
+    <meta property="og:description" content="<%= description %>" />
+    <meta property="og:image" content="https://account.lib.umich.edu/icon-512x512.png" />
+    <meta property="og:image:alt" content="University of Michigan's Block M" />
+    <meta property="og:url" content="https://account.lib.umich.edu/"/>
+    <meta property="og:site_name" content="Erin E. Sullivan" />
+
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:site" content="@umichlibrary">
+    <meta name="twitter:image" content="https://account.lib.umich.edu/icon-512x512.png" />
+    <meta name="twitter:image:alt" content="University of Michigan's Block M" />
   </head>
   <body>
     <section aria-label="Skip links" class="site-skip-links">


### PR DESCRIPTION
# Overview
When running [Google Chrome's Lighthouse](https://developers.google.com/web/tools/lighthouse) on the site, `SEO` scored `91` out of `100`. The reason was because of the lack of a `meta description`. This PR creates a description model and applies it to the meta tags. Open Graph and Twitter card tags were also added, because why not? This brings the `SEO` score to `100`.

## Future
We should look into how we can increase performance.

## Testing
* Run tests and make sure they pass (`docker-compose run web bundle exec rspec`)
  * Break the tests to make sure they work.
* View the source code and see the descriptions in action.
* Update `config/navigation.json` and add/change/remove `"description"` properties to see what happens.
* Poke around the site to make sure nothing is broken.