### PR TITLE
Horizontal Navigation Updates

### DIFF
--- a/css/_base.scss
+++ b/css/_base.scss
@@ -63,21 +63,19 @@ h1 {
   line-height: var(--line-height-page-heading);
   margin-bottom: var(--space-large);
   &#maincontent {
+    outline: 0;
     position: relative;
     &::before {
-      background-color: transparent;
+      background-color: var(--color-teal-400);
       content: '';
       height: 100%;
       left: calc(var(--space-medium) * -1);
       position: absolute;
       width: var(--space-xx-small);
     }
-    &:focus-visible,
-    &:focus-within,
-    &:focus {
-      outline: 0;
+    &:not(:focus):not(:focus-within) {
       &::before {
-        background-color: var(--color-teal-400);
+        background-color: transparent;
       }
     }
   }

--- a/css/_base.scss
+++ b/css/_base.scss
@@ -62,6 +62,25 @@ h1 {
   font-size: var(--text-xxx-large);
   line-height: var(--line-height-page-heading);
   margin-bottom: var(--space-large);
+  &#maincontent {
+    position: relative;
+    &::before {
+      background-color: transparent;
+      content: '';
+      height: 100%;
+      left: calc(var(--space-medium) * -1);
+      position: absolute;
+      width: var(--space-xx-small);
+    }
+    &:focus-visible,
+    &:focus-within,
+    &:focus {
+      outline: 0;
+      &::before {
+        background-color: var(--color-teal-400);
+      }
+    }
+  }
 }
 
 h2,

--- a/css/_horizontal-navigation.scss
+++ b/css/_horizontal-navigation.scss
@@ -72,10 +72,4 @@
       }
     }
   }
-  
-  .horizontal-heading {
-    margin-bottom: var(--space-small);
-    margin-top: var(--space-xx-large);
-    order: 2;
-  }
 }

--- a/lib/navigation/title.rb
+++ b/lib/navigation/title.rb
@@ -4,7 +4,7 @@ class Navigation::Title < Navigation
   end
   def to_s
     title = ''
-    title = "#{@page.parent.title} : " if @page.parent
+    title = "#{@page.parent.title}: " if @page.parent
     title = title + @page.title
   end
 end

--- a/spec/lib/navigation/title_spec.rb
+++ b/spec/lib/navigation/title_spec.rb
@@ -6,7 +6,7 @@ describe Navigation::Title do
   end
   context "dropdown for child page" do
     it "has correct title string" do
-      expect(described_class.for('/current-checkouts/u-m-library').to_s).to eq('Current Checkouts : U-M Library')
+      expect(described_class.for('/current-checkouts/u-m-library').to_s).to eq('Current Checkouts: U-M Library')
     end
   end
 end

--- a/views/account-overview/index.erb
+++ b/views/account-overview/index.erb
@@ -1,23 +1,15 @@
-<!--
-  Could this data come from back-end?
-
-  Maybe some configured data related to side navigation
-  and homepage cards could be grouped? Flag navigation
-  elements that should be these overview cards and filter
-  them to this view, or something.
--->
 <ul class="overview-cards">
-<% cards.each do |card| %>
-  <li>
-    <a href="<%=card.slug%>" class="overview-card">
-      <div>
-        <h2 class="overview-card-heading"><%=card.title%></h2>
-        <p class="overview-card-description"><%=card.description%></p>
-      </div>
-      <div class="overview-card-icon-container" style="--overview-card-icon-background-color: var(--color-<%=card.color%>-100); --overview-card-icon-color: var(--color-<%=card.color%>-400);">
-        <m-icon name="<%=card.icon_name%>"></m-icon>
-      </div>
-    </a>
-  </li>
-<% end %>
+  <% cards.each do |card| %>
+    <li>
+      <a href="<%=card.slug%>" class="overview-card">
+        <div>
+          <h2 class="overview-card-heading"><%=card.title%></h2>
+          <p class="overview-card-description"><%=card.description%></p>
+        </div>
+        <div class="overview-card-icon-container" style="--overview-card-icon-background-color: var(--color-<%=card.color%>-100); --overview-card-icon-color: var(--color-<%=card.color%>-400);">
+          <m-icon name="<%=card.icon_name%>"></m-icon>
+        </div>
+      </a>
+    </li>
+  <% end %>
 </ul>

--- a/views/current-checkouts/u-m-library.erb
+++ b/views/current-checkouts/u-m-library.erb
@@ -9,7 +9,7 @@
 <% end %>
 
 <div class="progress-container" aria-live="polite" style="display: none;">
-  <h2 class="progress-heading">Step 1 of 3</h2>
+  <h3 class="progress-heading">Step 1 of 3</h3>
   <label>
     <span class="progress-label-text">Fetching loans...</span>
     <progress 

--- a/views/development_users.erb
+++ b/views/development_users.erb
@@ -19,7 +19,7 @@
 %>
   <div class="message-callout">
     <div class="prose owl">
-      <h2 style="margin-top: 0;">design & development options</h2>
+      <h2 style="margin-top: 0;">Design &amp; Development Options</h2>
   
       <form method="get" action="/session_switcher" class="prose owl">
         <label for="test-user">

--- a/views/empty_state.erb
+++ b/views/empty_state.erb
@@ -4,7 +4,7 @@
 
 <section class="empty-state-container">
   <div class="empty-state-content owl">
-    <h2><%=empty_state.heading%></h2>
+    <h3><%=empty_state.heading%></h3>
     <p><%=empty_state.message%></p>
   </div>
 

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -67,7 +67,7 @@
       <%= erb :'layout/user_drop_down' %>
     </m-website-header>
     <%= erb :'layout/banner' %>
-    <main class="layout site-layout" id="maincontent" tabindex="-1">
+    <main class="layout site-layout">
       <%= erb :'layout/navigation' %>
       <article class="site-layout__center owl prose">
         <%= erb :'layout/horizontal_nav' %>
@@ -95,7 +95,9 @@
         </section>
       </div>
     </footer>
-    <m-chat id="chat" tabindex="-1"></m-chat>
+    <m-chat>
+      <div id="chat" tabindex="-1"></div>
+    </m-chat>
     <script src="/bundles/main.bundle.js"></script>
     <% if defined?(has_js)  %>
       <script src="/bundles/<%=request.js_filename%>.bundle.js"></script>

--- a/views/layout/horizontal_nav.erb
+++ b/views/layout/horizontal_nav.erb
@@ -31,6 +31,6 @@
     </ul>
   </nav>
 
-  <h2 class="horizontal-heading"><%=horizontal_nav.title%></h2>
+  <h2><%=horizontal_nav.title%></h2>
 
 <% end %>

--- a/views/layout/horizontal_nav.erb
+++ b/views/layout/horizontal_nav.erb
@@ -13,13 +13,13 @@
 
 <% if horizontal_nav.nil?%>
 
-  <h1><%=page.title%></h1>
+  <h1 id="maincontent" tabindex="-1"><%=page.title%></h1>
 
 <% else %>
 
-  <h1 id="main-heading"><%=horizontal_nav.section%><span class="visually-hidden">: <%=horizontal_nav.title%></span></h1>
+  <h1 id="maincontent" tabindex="-1"><%=horizontal_nav.section%><span class="visually-hidden">: <%=horizontal_nav.title%></span></h1>
 
-  <nav aria-labelledby="main-heading" class="horizontal-navigation-container">
+  <nav aria-labelledby="maincontent" class="horizontal-navigation-container">
     <ul class="horizontal-navigation-list">
         <% horizontal_nav.children.each do |child| %>
           <li>

--- a/views/layout/horizontal_nav.erb
+++ b/views/layout/horizontal_nav.erb
@@ -17,20 +17,20 @@
 
 <% else %>
 
-  <h1 aria-hidden="true"><%=horizontal_nav.section%></h1>
+  <h1 id="main-heading"><%=horizontal_nav.section%><span class="visually-hidden">: <%=horizontal_nav.title%></span></h1>
 
   <nav aria-labelledby="main-heading" class="horizontal-navigation-container">
-    <h1 class="h2 horizontal-heading" id="main-heading"><span class="visually-hidden"><%=horizontal_nav.section%>: </span><%=horizontal_nav.title%></h1>
-
     <ul class="horizontal-navigation-list">
         <% horizontal_nav.children.each do |child| %>
           <li>
-            <a href="<%=child.path%>"  <% if child.active? %>aria-current="page"<% end %>>
+            <a href="<%=child.path%>" <% if child.active? %>aria-current="page"<% end %>>
               <%=child.title%>
             </a>
           </li>
         <% end %>
     </ul>
   </nav>
+
+  <h2 class="horizontal-heading"><%=horizontal_nav.title%></h2>
 
 <% end %>

--- a/views/settings/_modal.erb
+++ b/views/settings/_modal.erb
@@ -14,7 +14,7 @@
       </div>
     <% end %>
     <div class="modal-content owl">
-      <h2 id="<%= modal[:id] %>-heading"><%= modal[:content][:heading] %></h2>
+      <h3 id="<%= modal[:id] %>-heading"><%= modal[:content][:heading] %></h3>
       <p id="<%= modal[:id] %>-text"><%= modal[:content][:text] %></p>
     </div>
     <% if modal[:button] %>


### PR DESCRIPTION
# Overview
In an effort to reduce `ARC Toolkit` warnings, the horizontal navigation has been restructured. Styles and headings have also been updated, along with some general cleanup.

## Testing
* Run tests to see if they pass `docker-compose run web bundle exec rspec`
  * Break the tests to make sure they're working.
* Go through the site to make sure nothing is broken.