### PR TITLE
Settings: Text Notifications - Replace Toggle

### DIFF
--- a/css/_fines.scss
+++ b/css/_fines.scss
@@ -1,17 +1,5 @@
-#pay-some-amount {
-  max-width: 30rem;
-  padding-left: 2.5rem;
-  position: relative;
-  & > span {
-    left: 1.5rem;
-    position: absolute;
-    top: 0.5em;
-  }
-  m-icon {
-    color: inherit;
-  }
-}
-
-#pay-some:not(:checked) ~ #pay-some-amount {
-  display: none;
+#pay-some-amount > span {
+  left: 0.25rem;
+  position: absolute;
+  top: 0.5em;
 }

--- a/css/_patron.scss
+++ b/css/_patron.scss
@@ -1,5 +1,0 @@
-form[method="post"] {
-  #text-notifications:not(:checked) ~ .sms-number-container {
-    display: none;
-  }
-}

--- a/css/_utilities.scss
+++ b/css/_utilities.scss
@@ -49,7 +49,7 @@
   color: var(--color-orange-500);
 }
 
-.narrow-content {
+.narrow-content > *:not(.responsive-table) {
   max-width: 36rem;
 }
 

--- a/css/index.scss
+++ b/css/index.scss
@@ -21,5 +21,4 @@
 "renew",
 "modal",
 "fines",
-"patron",
 "maybe-design-system/controls";

--- a/css/maybe-design-system/_controls.scss
+++ b/css/maybe-design-system/_controls.scss
@@ -58,50 +58,6 @@ select::-ms-expand {
   display: none;
 }
 
-.toggle-switch {
-  & + .toggle-switch-label {
-    .toggle {
-      background-color: var(--color-neutral-200);
-      border: 1px solid var(--color-neutral-200);
-      border-radius: var(--space-medium);
-      display: inline-block;
-      height: 1.5em;
-      margin-right: var(--space-x-small);
-      position: relative;
-      top: var(--space-x-small);
-      transition: none 0.2s ease-in-out;
-      transition-property: background-color, border-color;
-      width: 3em;
-      &:before {
-        content: '';
-        background-color: white;
-        border-radius: var(--space-medium);
-        display: block;
-        height: 100%;
-        left: 0;
-        position: absolute;
-        transition: left 0.2s ease-in-out;
-        width: 50%;
-      }
-    }
-  }
-  &:checked + .toggle-switch-label {
-    .toggle {
-      background-color: var(--color-teal-400);
-      border-color: var(--color-teal-400);
-      &:before {
-        left: 50%;
-      }
-    }
-  }
-  &:focus + .toggle-switch-label {
-    .toggle {
-      outline: 0;
-      box-shadow: 0 0 0 2px var(--color-maize-400),0 0 0 3px var(--color-neutral-400);
-    }
-  }
-}
-
 .input-description {
   color: inherit;
   span {
@@ -115,7 +71,8 @@ select::-ms-expand {
 .radio-option {
   input[type="radio"] {
     &:checked + label m-icon[name="radio-button-unchecked"],
-    &:not(:checked) + label m-icon[name="radio-button-checked"] {
+    &:not(:checked) + label m-icon[name="radio-button-checked"],
+    &:not(:checked) ~ .radio-option-extra {
       display: none;
     }
     &:not(:checked) + label m-icon {
@@ -132,5 +89,13 @@ select::-ms-expand {
     position: relative;
     margin-right: var(--space-xx-small);
     top: var(--space-xxx-small);
+  }
+  .radio-option-extra {
+    margin-top: var(--space-medium);
+    padding-left: 1.5rem;
+    position: relative;
+    m-icon {
+      color: inherit;
+    }
   }
 }

--- a/views/fines-and-fees/index.erb
+++ b/views/fines-and-fees/index.erb
@@ -1,11 +1,11 @@
 <% if fines.count == 0 %>
 
-<%= erb :empty_state %>
+  <%= erb :empty_state %>
 
 <% elsif %>
-  <p>You are charged <a href="https://lib.umich.edu/find-borrow-request/borrow-and-return/reminders-and-overdue-items">overdue fines</a> for high-use materials that are returned late. This includes material from the Askwith Media Library, course reserves, and other items that have been "recalled" or are lost or damaged.</p>
-
-  <form action="/fines-and-fees/pay" method="post" class="owl">
+  <div class="owl narrow-content">
+    <p>You are charged <a href="https://lib.umich.edu/find-borrow-request/borrow-and-return/reminders-and-overdue-items">overdue fines</a> for high-use materials that are returned late. This includes material from the Askwith Media Library, course reserves, and other items that have been "recalled" or are lost or damaged.</p>
+    
     <div class="responsive-table">
       <table>
         <thead>
@@ -33,65 +33,67 @@
       </table>
     </div>
 
-    <p>Your total due is <span class="strong">$<%=fines.total_sum_in_dollars%></span></p>
+    <form action="/fines-and-fees/pay" method="post" class="owl">
+      <p>Your total due is <span class="strong">$<%=fines.total_sum_in_dollars%></span></p>
 
-    <h2>How much would you like to pay today?</h2>
+      <h2>How much would you like to pay today?</h2>
 
-    <fieldset class="owl">
-      <legend class="visually-hidden">Pick a payment amount option</legend>
-      <div class="radio-option">
-        <input 
-          type="radio"
-          name="pay_in_full"
-          class="visually-hidden"
-          id="pay-all"
-          value="true"
-        >
-        <label for="pay-all">
-          <m-icon name="radio-button-checked"></m-icon>
-          <m-icon name="radio-button-unchecked"></m-icon>
-          <span>Pay full amount (<span class="strong">$<%=fines.total_sum_in_dollars%></span>)</span>
-        </label>
-      </div>
-      <div class="radio-option">
-        <input 
-          type="radio"
-          name="pay_in_full"
-          class="visually-hidden"
-          id="pay-some"
-          value="false" 
-        >
-        <label for="pay-some">
-          <m-icon name="radio-button-checked"></m-icon>
-          <m-icon name="radio-button-unchecked"></m-icon>
-          <span>Pay partial amount</span>
-        </label>
-        <div id="pay-some-amount">
-          <span>$</span>
+      <fieldset class="owl">
+        <legend class="visually-hidden">Pick a payment amount option</legend>
+        <div class="radio-option">
           <input
-            type="number"
-            min="0.00"
-            max="<%=fines.total_sum_in_dollars%>"
-            step="0.01"
-            pattern="^\d+\.\d{2}$"
-            value="0.00"
-            name="partial_amount"
-            for="pay-some"
-            aria-label="Amount you wish to pay"
-            aria-describedby="payment-description"
-            autocomplete="off"
+            type="radio"
+            name="pay_in_full"
+            class="visually-hidden"
+            id="pay-all"
+            value="true"
           >
-          <div id="payment-description" class="input-description">
-            <m-icon name="info"></m-icon><span>Payment amount must include cents. Example: 25.00</span>
+          <label for="pay-all">
+            <m-icon name="radio-button-checked"></m-icon>
+            <m-icon name="radio-button-unchecked"></m-icon>
+            <span>Pay full amount (<span class="strong">$<%=fines.total_sum_in_dollars%></span>)</span>
+          </label>
+        </div>
+        <div class="radio-option">
+          <input
+            type="radio"
+            name="pay_in_full"
+            class="visually-hidden"
+            id="pay-some"
+            value="false"
+          >
+          <label for="pay-some">
+            <m-icon name="radio-button-checked"></m-icon>
+            <m-icon name="radio-button-unchecked"></m-icon>
+            <span>Pay partial amount</span>
+          </label>
+          <div id="pay-some-amount" class="radio-option-extra">
+            <span>$</span>
+            <input
+              type="number"
+              min="0.00"
+              max="<%=fines.total_sum_in_dollars%>"
+              step="0.01"
+              pattern="^\d+\.\d{2}$"
+              value="0.00"
+              name="partial_amount"
+              for="pay-some"
+              aria-label="Amount you wish to pay"
+              aria-describedby="payment-description"
+              autocomplete="off"
+            >
+            <div id="payment-description" class="input-description">
+              <m-icon name="info"></m-icon><span>Payment amount must include cents. Example:&nbsp;25.00</span>
+            </div>
           </div>
         </div>
-      </div>
-    </fieldset>
+      </fieldset>
 
-    <button type="submit">Pay fines</button>
+      <button type="submit">Pay fines</button>
 
-    <p><span class="strong">Payments made are non-refundable</span>.</p>
-    
-    <p>If you have a question about your account or would like to contest a fine, please contact us at the <a href="https://lib.umich.edu/locations-and-hours/hatcher-library/hatcher-north-information-services-desk">Hatcher North Information Services Desk</a> before making payments.</p>
-  </form>
+      <p><span class="strong">Payments made are non-refundable</span>.</p>
+
+      <p>If you have a question about your account or would like to contest a fine, please contact us at the <a href="https://lib.umich.edu/locations-and-hours/hatcher-library/hatcher-north-information-services-desk">Hatcher North Information Services Desk</a> before making payments.</p>
+    </form>
+  </div>
 <% end %>

--- a/views/settings/index.erb
+++ b/views/settings/index.erb
@@ -94,30 +94,6 @@
         </div>
       </fieldset>
 
-      <!--<input type="checkbox" class="toggle-switch visually-hidden" id="text-notifications" name="text-notifications" <% if patron.sms_number? %>checked<% end%>>
-      <label class="toggle-switch-label" for="text-notifications">
-        <div class="toggle"></div>
-        <span>You wish to receive text notifications</span>
-      </label>
-
-      <div class="sms-number-container">
-        <label class="text-notifications-label" for="sms-number">
-          Phone number
-        </label>
-        <input
-          type="tel"
-          name="sms-number"
-          id="sms-number"
-          value="<%= patron.sms_number %>"
-          pattern="\(\d{3}\) \d{3}-\d{4}"
-          aria-describedby="sms-number-description"
-          autocomplete="on"
-        />
-        <div id="sms-number-description" class="input-description">
-          <m-icon name="info"></m-icon><span>Phone number must be 10 digits. Example: (123) 456-7890.</span>
-        </div>
-      </div>-->
-
       <button>Update notification preferences</button>
     </form>
   <% end %>

--- a/views/settings/index.erb
+++ b/views/settings/index.erb
@@ -43,7 +43,58 @@
 
       <p>Add a phone number to receive text notifications on the status of your request and loans. Special collections requests are not included. Message and data rates may apply.</p>
 
-      <input type="checkbox" class="toggle-switch visually-hidden" id="text-notifications" name="text-notifications" <% if patron.sms_number? %>checked<% end%>>
+      <fieldset class="owl">
+        <legend class="visually-hidden">Do you wish to receive text notifications?</legend>
+        <div class="radio-option">
+          <input 
+            type="radio"
+            name="text-notifications"
+            class="visually-hidden"
+            id="confirm-sms"
+            value="on"
+            <% if patron.sms_number? %>checked<% end%>
+          >
+          <label for="confirm-sms">
+            <m-icon name="radio-button-checked"></m-icon>
+            <m-icon name="radio-button-unchecked"></m-icon>
+            <span>Yes, please send me text notifications</span>
+          </label>
+          <div class="radio-option-extra">
+            <label class="text-notifications-label" for="sms-number">
+              Phone number
+            </label>
+            <input
+              type="tel"
+              name="sms-number"
+              id="sms-number"
+              value="<%= patron.sms_number %>"
+              pattern="\(\d{3}\) \d{3}-\d{4}"
+              aria-describedby="sms-number-description"
+              autocomplete="on"
+            />
+            <div id="sms-number-description" class="input-description">
+              <m-icon name="info"></m-icon><span>Phone number must be 10 digits. Example:&nbsp;(123)&nbsp;456-7890.</span>
+            </div>
+          </div>
+        </div>
+        <div class="radio-option">
+          <input 
+            type="radio"
+            name="text-notifications"
+            class="visually-hidden"
+            id="deny-sms"
+            value="off"
+            <% if !patron.sms_number? %>checked<% end%>
+          >
+          <label for="deny-sms">
+            <m-icon name="radio-button-checked"></m-icon>
+            <m-icon name="radio-button-unchecked"></m-icon>
+            <span>No, do not send me text notifications</span>
+          </label>
+        </div>
+      </fieldset>
+
+      <!--<input type="checkbox" class="toggle-switch visually-hidden" id="text-notifications" name="text-notifications" <% if patron.sms_number? %>checked<% end%>>
       <label class="toggle-switch-label" for="text-notifications">
         <div class="toggle"></div>
         <span>You wish to receive text notifications</span>
@@ -65,7 +116,7 @@
         <div id="sms-number-description" class="input-description">
           <m-icon name="info"></m-icon><span>Phone number must be 10 digits. Example: (123) 456-7890.</span>
         </div>
-      </div>
+      </div>-->
 
       <button>Update notification preferences</button>
     </form>


### PR DESCRIPTION
# Overview
> Make the Settings -> Text Notifications a radio button so it's consistent with checkout history and the update button doesn't feel weird.

`Text Notifications` was the only place that used a toggle. The logic could easily be converted to radio buttons. Some also found the functionality/content of the toggle to be confusing. Some styles were also cleaned up.

Resolves #183.

## Testing
* Run tests (`docker-compose run web bundle exec rspec`)
  * Break the tests to make sure they work.
* Check [Settings](http://localhost:4567/settings) and [Fines and Fees](http://localhost:4567/fines-and-fees) to make sure nothing is broken.