### PR TITLE
ILLiad - Adding extra author information

### DIFF
--- a/models/items/interlibrary_loan/interlibrary_loan_item.rb
+++ b/models/items/interlibrary_loan/interlibrary_loan_item.rb
@@ -3,7 +3,7 @@ class InterlibraryLoanItem < Item
     super
     if @parsed_response["RequestType"] == "Article"
       @title = "#{@parsed_response["PhotoJournalTitle"] || ""} #{@parsed_response["PhotoArticleTitle"] || ""}"
-      @author = @parsed_response["PhotoArticleAuthor"] || ""
+      @author = @parsed_response["PhotoArticleAuthor"] || @parsed_response["PhotoItemAuthor"] || ""
       @description = !@parsed_response["PhotoJournalVolume"].nil? ? "vol #{@parsed_response["PhotoJournalVolume"]}" : ""
     else
       @title = @parsed_response["LoanTitle"] || ""

--- a/models/items/interlibrary_loan/interlibrary_loan_item.rb
+++ b/models/items/interlibrary_loan/interlibrary_loan_item.rb
@@ -2,8 +2,8 @@ class InterlibraryLoanItem < Item
   def initialize(parsed_response)
     super
     if @parsed_response["RequestType"] == "Article"
-      @title = "#{@parsed_response["PhotoJournalTitle"] || ""} #{@parsed_response["PhotoArticleTitle"] || ""}"
-      @author = @parsed_response["PhotoArticleAuthor"] || @parsed_response["PhotoItemAuthor"] || ""
+      @title = [@parsed_response['PhotoJournalTitle'], @parsed_response['PhotoArticleTitle']].reject { |e| e.to_s.empty? }.join(': ')
+      @author = [@parsed_response['PhotoArticleAuthor'], @parsed_response['PhotoItemAuthor']].reject { |e| e.to_s.empty? }.join('; ')
       @description = !@parsed_response["PhotoJournalVolume"].nil? ? "vol #{@parsed_response["PhotoJournalVolume"]}" : ""
     else
       @title = @parsed_response["LoanTitle"] || ""

--- a/spec/models/items/interlibrary_loan/document_delivery_spec.rb
+++ b/spec/models/items/interlibrary_loan/document_delivery_spec.rb
@@ -6,8 +6,7 @@ describe DocumentDelivery do
     before(:each) do
       requests = JSON.parse(File.read('./spec/fixtures/illiad_requests.json'))
       body = [requests[3]].to_json
-      stub_illiad_get_request(url: "Transaction/UserRequests/testhelp", body: body, query: {"$filter" =>"RequestType eq 'Article' and TransactionStatus eq 'Delivered to Web'"}
- )
+      stub_illiad_get_request(url: "Transaction/UserRequests/testhelp", body: body, query: {"$filter" =>"RequestType eq 'Article' and TransactionStatus eq 'Delivered to Web'"})
     end
     subject do
       DocumentDelivery.for(uniqname: 'testhelp')
@@ -41,19 +40,21 @@ end
 
 describe DocumentDeliveryItem do
   before(:each) do
-    @delivery = JSON.parse(File.read("./spec/fixtures/illiad_requests.json"))[3]
+    item = JSON.parse(File.read("./spec/fixtures/illiad_requests.json"))[3]
+    item["PhotoItemAuthor"] = "B. Authorwoman"
+    @delivery = item
   end
   subject do
     DocumentDeliveryItem.new(@delivery) 
   end
   context "#title" do
     it "returns title string" do
-      expect(subject.title).to eq("A Book About Things Chapter One")
+      expect(subject.title).to eq("A Book About Things: Chapter One")
     end
   end
   context "#author" do
     it "returns author string" do
-      expect(subject.author).to eq("A. Authorman")
+      expect(subject.author).to eq("A. Authorman; B. Authorwoman")
     end
   end
   context "#illiad_id" do

--- a/spec/models/items/interlibrary_loan/interlibrary_loan_item_spec.rb
+++ b/spec/models/items/interlibrary_loan/interlibrary_loan_item_spec.rb
@@ -10,7 +10,7 @@ describe InterlibraryLoanItem do
   end
   context "#title" do
     it "returns title string" do
-      expect(subject.title).to eq("Journal of Stuff and Things What I Think")
+      expect(subject.title).to eq("Journal of Stuff and Things: What I Think")
     end
   end
   context "#author" do


### PR DESCRIPTION
# Overview
While seeing ILLiad pulling in my information, I noticed the author wasn't showing. 

Example:
```
Transaction Information
--
Journal Title | Angels &amp; Demons
Volume |  
Issue |  
Month |  
Year |  
Inclusive Pages | 3
Article Author |  
Article Title | 6
Item Author | Dan Brown
Item Place |  
Item Publisher |  
Item Edition |  
ISSN/ISBN | N/A
Cited In |  
Cited Title |  
Cited Date |  
Cited Volume |  
Cited Pages |  
Not Wanted After | 06/02/2021
Accept Non English |  
Accept Alternate Edition |  
Due Date |  
Renewals Allowed? |  
Max Cost |  

Tracking
--
3/4/2021 10:04:49 AM | Request Has Been Submitted to ILL
3/4/2021 10:04:49 AM | Request Has Been Submitted to ILL
3/4/2021 10:06:01 AM | Cancelled by Patron
```
Returned...
```
Angels & Demons 6 | Requested: 03/04/21 | Returned: 03/04/21
```

This PR now makes `@author` include `@parsed_response["PhotoItemAuthor"]`.

## Testing
* Run tests (`docker-compose run web bundle exec rspec`)
  * Break tests to make sure they work.
* Check all ILLiad pages to make sure they're not broken.