### PR TITLE
Settings: Checkout History - Unchecked buttons

### DIFF
--- a/css/_modal.scss
+++ b/css/_modal.scss
@@ -4,7 +4,7 @@
   display: flex;
   height: 100%;
   left: 0;
-  margin: 0!important;
+  margin: 0;
   padding: var(--space-medium);
   position: fixed;
   right: 0;

--- a/css/_modal.scss
+++ b/css/_modal.scss
@@ -4,7 +4,7 @@
   display: flex;
   height: 100%;
   left: 0;
-  margin: 0;
+  margin: 0!important;
   padding: var(--space-medium);
   position: fixed;
   right: 0;

--- a/css/_utilities.scss
+++ b/css/_utilities.scss
@@ -21,8 +21,16 @@
   }
 }
 
-.owl > *:not(.visually-hidden:first-child) + * {
-  margin-top: var(--space-medium);
+.owl {
+  & > * + * {
+    margin-top: var(--space-medium);
+  }
+  & > .visually-hidden {
+    &,
+    &:first-child + * {
+      margin-top: 0;
+    }
+  }
 }
 
 .sticky-top {

--- a/css/_utilities.scss
+++ b/css/_utilities.scss
@@ -21,7 +21,7 @@
   }
 }
 
-.owl > * + * {
+.owl > *:not(.visually-hidden:first-child) + * {
   margin-top: var(--space-medium);
 }
 

--- a/views/settings/index.erb
+++ b/views/settings/index.erb
@@ -112,7 +112,7 @@
           class="visually-hidden"
           id="opt-in" 
           value="true" 
-          <% if patron.confirmed_history_setting? && patron.retain_history?  %>checked<% end %>
+          <% if patron.confirmed_history_setting? && patron.retain_history? %>checked<% end %>
         >
         <label for="opt-in">
           <m-icon name="radio-button-checked"></m-icon>

--- a/views/settings/index.erb
+++ b/views/settings/index.erb
@@ -112,7 +112,7 @@
           class="visually-hidden"
           id="opt-in" 
           value="true" 
-          <% if patron.retain_history? %>checked<% end %>
+          <% if patron.confirmed_history_setting? && patron.retain_history?  %>checked<% end %>
         >
         <label for="opt-in">
           <m-icon name="radio-button-checked"></m-icon>
@@ -127,7 +127,7 @@
           class="visually-hidden" 
           id="opt-out" 
           value="false" 
-          <% if !patron.retain_history? %>checked<% end %>
+          <% if patron.confirmed_history_setting? && !patron.retain_history? %>checked<% end %>
         >
         <label for="opt-out">
           <m-icon name="radio-button-checked"></m-icon>


### PR DESCRIPTION
# Overview
In [Settings](http://localhost:4567/settings) under `Checkout History`, if the user has not confirmed whether or not they wish to retain their checkout history, the radio button automatically has `No, do not send me text notifications` selected. This was because it was only checking if `retain_history` did not exist or was set to `false`, without actually checking if the user has confirmed their history settings. This PR adds that confirmation check.

## Testing
* Go to [Settings](http://localhost:4567/settings) and set the `Active user account` to each user and see if:
 1) The banner does or does not display if the user has not or has confirmed their checkout history settings
 2) The radio options has no options checked (if not confirmed), or has the correct option checked (if confirmed).