### PR TITLE
ILLiad Pagination

### DIFF
--- a/my_account.rb
+++ b/my_account.rb
@@ -187,12 +187,12 @@ namespace '/current-checkouts' do
   end
   
   get '/interlibrary-loan' do
-    interlibrary_loans = InterlibraryLoans.for(uniqname: session[:uniqname])
+    interlibrary_loans = InterlibraryLoans.for(uniqname: session[:uniqname], limit: params["limit"], offset: params["offset"], count: nil)
 
     erb :'current-checkouts/interlibrary-loan', :locals => { interlibrary_loans: interlibrary_loans }
   end
   get '/scans-and-electronic-items' do
-    document_delivery = DocumentDelivery.for(uniqname: session[:uniqname])
+    document_delivery = DocumentDelivery.for(uniqname: session[:uniqname], limit: params["limit"], offset: params["offset"], count: nil)
 
     erb :'current-checkouts/scans-and-electronic-items', :locals => { document_delivery: document_delivery }
   end
@@ -232,7 +232,7 @@ namespace '/pending-requests' do
 
 
   get '/interlibrary-loan' do
-    interlibrary_loan_requests = InterlibraryLoanRequests.for(uniqname: session[:uniqname])
+    interlibrary_loan_requests = InterlibraryLoanRequests.for(uniqname: session[:uniqname], limit: params["limit"], offset: params["offset"], count: nil)
 
     erb :'pending-requests/interlibrary-loan', :locals => { interlibrary_loan_requests: interlibrary_loan_requests }
   end

--- a/spec/models/items/interlibrary_loan/document_delivery_spec.rb
+++ b/spec/models/items/interlibrary_loan/document_delivery_spec.rb
@@ -2,18 +2,19 @@ require 'spec_helper'
 require 'json'
 
 describe DocumentDelivery do
+  let(:query){{"$filter" => "RequestType eq 'Article' and TransactionStatus eq 'Delivered to Web'", "$top" => '15'}}
   context "one loan" do
     before(:each) do
       requests = JSON.parse(File.read('./spec/fixtures/illiad_requests.json'))
       body = [requests[3]].to_json
-      stub_illiad_get_request(url: "Transaction/UserRequests/testhelp", body: body, query: {"$filter" =>"RequestType eq 'Article' and TransactionStatus eq 'Delivered to Web'"})
+      stub_illiad_get_request(url: "Transaction/UserRequests/testhelp", body: body, query: query)
     end
     subject do
-      DocumentDelivery.for(uniqname: 'testhelp')
+      DocumentDelivery.for(uniqname: 'testhelp', count: 25)
     end
     context "#count" do
       it "returns total request item count" do
-        expect(subject.count).to eq(1)
+        expect(subject.count).to eq(25)
       end
     end
     context "#each" do
@@ -32,74 +33,32 @@ describe DocumentDelivery do
     end
     context "#item_text" do
       it "returns 'item' if there is only one loan, or 'items' if there is not" do
-        expect(subject.item_text).to eq('item')
+        expect(subject.item_text).to eq('items')
       end
     end
   end
-end
-
-describe DocumentDeliveryItem do
-  before(:each) do
-    item = JSON.parse(File.read("./spec/fixtures/illiad_requests.json"))[3]
-    item["PhotoItemAuthor"] = "B. Authorwoman"
-    @delivery = item
-  end
-  subject do
-    DocumentDeliveryItem.new(@delivery) 
-  end
-  context "#title" do
-    it "returns title string" do
-      expect(subject.title).to eq("A Book About Things: Chapter One")
+  context "no count given" do
+    before(:each) do
+      requests = JSON.parse(File.read('./spec/fixtures/illiad_requests.json'))
+      body = [requests[3]].to_json
+      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: body, query: {'$filter': query['$filter']})
     end
-  end
-  context "#author" do
-    it "returns author string" do
-      expect(subject.author).to eq("A. Authorman; B. Authorwoman")
+    subject do
+      DocumentDelivery.for(uniqname: 'testhelp', limit: '1', count: nil)
     end
-  end
-  context "#illiad_id" do
-    it "returns the ILLiad transaction ID" do
-      expect(subject.illiad_id).to eq(3298028)
-    end
-  end
-  context "#illiad_url" do
-    it "returns ILLIAD url based on action number, form number, and if the form is actually type" do
-      expect(subject.illiad_url(42, 1887, true)).to eq("https://ill.lib.umich.edu/illiad/illiad.dll?Action=42&Type=1887&Value=3298028")
-    end
-  end
-  context "#url_transaction" do
-    it "returns url to the ILLiad transaction" do
-      expect(subject.url_transaction).to eq("https://ill.lib.umich.edu/illiad/illiad.dll?Action=10&Form=72&Value=3298028")
-    end
-  end
-  context "#url_cancel_request" do
-    it "returns url to cancel the ILLiad transaction request" do
-      expect(subject.url_cancel_request).to eq("https://ill.lib.umich.edu/illiad/illiad.dll?Action=21&Type=10&Value=3298028")
-    end
-  end
-  context "#url_request_renewal" do
-    it "returns url to the form to request a renewal of the ILLiad transaction" do
-      expect(subject.url_request_renewal).to eq("https://ill.lib.umich.edu/illiad/illiad.dll?Action=11&Form=71&Value=3298028")
-    end
-  end
-  context "#creation_date" do
-    it "returns creation date string" do
-      expect(subject.creation_date).to eq("03/09/21")
-    end
-  end
-  context "#expiration_date" do
-    it "returns expiration date string" do
-      expect(subject.expiration_date).to eq('')
-    end
-  end
-  context "#transaction_date" do
-    it "returns transaction date string" do
-      expect(subject.transaction_date).to eq("03/09/21")
-    end
-  end
-  context "#renewable?" do
-    it "returns a boolean" do
-      expect(subject.renewable?).to eq(false)
+    context "#count" do
+      it "returns total number of transactions" do
+        expect(subject.count).to eq(1)
+      end
+    end 
+    context "#each" do
+      it "returns limit number of Loan objects" do
+        items = ''
+        subject.each do |item|
+          items = items + item.class.name
+        end
+        expect(items).to eq("DocumentDeliveryItem"*1)
+      end
     end
   end
 end

--- a/spec/models/items/interlibrary_loan/interlibrary_loan_requests_spec.rb
+++ b/spec/models/items/interlibrary_loan/interlibrary_loan_requests_spec.rb
@@ -2,21 +2,21 @@ require 'spec_helper'
 require 'json'
 
 describe InterlibraryLoanRequests do
+  let(:query){{"$filter" => "TransactionStatus ne 'Request Finished' and TransactionStatus ne 'Cancelled by ILL Staff' and TransactionStatus ne 'Cancelled by Customer' and TransactionStatus ne 'Delivered to Web' and TransactionStatus ne 'Checked Out to Customer' and ProcessType eq 'Borrowing'", "$top" => '15'}}
   context "two requests" do
     before(:each) do
-      filter = "TransactionStatus ne 'Request Finished' and TransactionStatus ne 'Cancelled by ILL Staff' and TransactionStatus ne 'Cancelled by Customer' and TransactionStatus ne 'Delivered to Web' and TransactionStatus ne 'Checked Out to Customer' and ProcessType eq 'Borrowing'"
       requests = JSON.parse(File.read('./spec/fixtures/illiad_requests.json'))
       requests.delete_at(0)
       requests[2]["TransactionStatus"] = "Request Has Been Submitted to ILL"
       requests[3]["TransactionStatus"] = "Awaiting Request Processing"
-      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: requests.to_json, query: {"$filter" => filter})
+      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: requests.to_json, query: query)
     end
     subject do
-      InterlibraryLoanRequests.for(uniqname: 'testhelp')
+      InterlibraryLoanRequests.for(uniqname: 'testhelp', count: 25)
     end
     context "#count" do
       it "returns total request item count" do
-        expect(subject.count).to eq(4)
+        expect(subject.count).to eq(25)
       end
     end
     context "#each" do
@@ -36,6 +36,32 @@ describe InterlibraryLoanRequests do
     context "#item_text" do
       it "returns 'item' if there is only one request, or 'items' if there is not" do
         expect(subject.item_text).to eq('items')
+      end
+    end
+  end
+  context "no count given" do
+    before(:each) do
+      requests = JSON.parse(File.read('./spec/fixtures/illiad_requests.json'))
+      requests.delete_at(0)
+      requests[2]["TransactionStatus"] = "Request Has Been Submitted to ILL"
+      requests[3]["TransactionStatus"] = "Awaiting Request Processing"
+      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: requests.to_json, query: {'$filter': query['$filter']})
+    end
+    subject do
+      InterlibraryLoanRequests.for(uniqname: 'testhelp', limit: '1', count: nil)
+    end
+    context "#count" do
+      it "returns total number of transactions" do
+        expect(subject.count).to eq(4)
+      end
+    end 
+    context "#each" do
+      it "returns limit number of Loan objects" do
+        items = ''
+        subject.each do |item|
+          items = items + item.class.name
+        end
+        expect(items).to eq("InterlibraryLoanRequest"*1)
       end
     end
   end

--- a/spec/models/items/interlibrary_loan/interlibrary_loans_spec.rb
+++ b/spec/models/items/interlibrary_loan/interlibrary_loans_spec.rb
@@ -2,18 +2,18 @@ require 'spec_helper'
 require 'json'
 
 describe InterlibraryLoans do
+  let(:query){{"$filter" => "RequestType eq 'Loan' and TransactionStatus eq 'Checked Out to Customer' and ProcessType eq 'Borrowing'", "$top" => '15'}}
   context "one loan" do
     before(:each) do
       body = [ JSON.parse(File.read('./spec/fixtures/illiad_requests.json'))[0] ].to_json
-    filter = "RequestType eq 'Loan' and TransactionStatus eq 'Checked Out to Customer' and ProcessType eq 'Borrowing'"
-      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: body, query: {"$filter" => filter})
+      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: body, query: query)
     end
     subject do
-      InterlibraryLoans.for(uniqname: 'testhelp')
+      InterlibraryLoans.for(uniqname: 'testhelp', count: 25)
     end
     context "#count" do
       it "returns total request item count" do
-        expect(subject.count).to eq(1)
+        expect(subject.count).to eq(25)
       end
     end
     context "#each" do
@@ -22,7 +22,7 @@ describe InterlibraryLoans do
         subject.each do |item|
           items = items + item.class.name
         end
-        expect(items).to eq('InterlibraryLoan')
+        expect(items).to eq('InterlibraryLoan'*1)
       end
     end
     context "#empty?" do
@@ -32,7 +32,30 @@ describe InterlibraryLoans do
     end
     context "#item_text" do
       it "returns 'item' if there is only one loan, or 'items' if there is not" do
-        expect(subject.item_text).to eq('item')
+        expect(subject.item_text).to eq('items')
+      end
+    end
+  end
+  context "no count given" do
+    before(:each) do
+      body = [ JSON.parse(File.read('./spec/fixtures/illiad_requests.json'))[0] ].to_json
+      stub_illiad_get_request(url: 'Transaction/UserRequests/testhelp', body: body, query: {'$filter': query['$filter']})
+    end
+    subject do
+      InterlibraryLoans.for(uniqname: 'testhelp', limit: '1', count: nil)
+    end
+    context "#count" do
+      it "returns total number of transactions" do
+        expect(subject.count).to eq(1)
+      end
+    end 
+    context "#each" do
+      it "returns limit number of Loan objects" do
+        items = ''
+        subject.each do |item|
+          items = items + item.class.name
+        end
+        expect(items).to eq("InterlibraryLoan"*1)
       end
     end
   end

--- a/views/current-checkouts/interlibrary-loan.erb
+++ b/views/current-checkouts/interlibrary-loan.erb
@@ -8,7 +8,7 @@
 <table>
   <caption>
     <div class="caption-flex">
-      <p>Showing <span class="strong"><%= interlibrary_loans.count %></span> <%= interlibrary_loans.item_text %></p>
+      <p>Showing <span class="strong"><%= interlibrary_loans.pagination.first %></span> - <span class="strong"><%= interlibrary_loans.pagination.last %></span> of <span class="strong"><%= interlibrary_loans.count %></span> <%= interlibrary_loans.item_text %></p>
     </div>
   </caption>
   <thead>
@@ -45,5 +45,7 @@
   </tbody>
 </table>
 </div>
+
+<%= erb :'components/pagination', locals: {pagination: interlibrary_loans.pagination, count: interlibrary_loans.count} %>
 
 <% end %>

--- a/views/current-checkouts/scans-and-electronic-items.erb
+++ b/views/current-checkouts/scans-and-electronic-items.erb
@@ -8,7 +8,7 @@
 <table>
   <caption>
     <div class="caption-flex">
-      <p>Showing <span class="strong"><%= document_delivery.count %></span> <%= document_delivery.item_text %></p>
+      <p>Showing <span class="strong"><%= document_delivery.pagination.first %></span> - <span class="strong"><%= document_delivery.pagination.last %></span> of <span class="strong"><%= document_delivery.count %></span> <%= document_delivery.item_text %></p>
     </div>
   </caption>
   <thead>
@@ -41,5 +41,7 @@
   </tbody>
 </table>
 </div>
+
+<%= erb :'components/pagination', locals: {pagination: document_delivery.pagination, count: document_delivery.count} %>
 
 <% end %>

--- a/views/pending-requests/interlibrary-loan.erb
+++ b/views/pending-requests/interlibrary-loan.erb
@@ -8,7 +8,7 @@
 <table>
   <caption>
     <div class="caption-flex">
-      <p>Showing <span class="strong"><%= interlibrary_loan_requests.count %></span> <%= interlibrary_loan_requests.item_text %></p>
+      <p>Showing <span class="strong"><%= interlibrary_loan_requests.pagination.first %></span> - <span class="strong"><%= interlibrary_loan_requests.pagination.last %></span> of <span class="strong"><%= interlibrary_loan_requests.count %></span> <%= interlibrary_loan_requests.item_text %></p>
     </div>
   </caption>
   <thead>
@@ -36,5 +36,7 @@
   </tbody>
 </table>
 </div>
+
+<%= erb :'components/pagination', locals: {pagination: interlibrary_loan_requests.pagination, count: interlibrary_loan_requests.count} %>
 
 <% end %>


### PR DESCRIPTION
# Overview
In [DNDHELP-3008](https://tools.lib.umich.edu/jira/browse/DNDHELP-3008?focusedCommentId=1057234&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1057234), the user was unable to view all of their requests. This is because pagination only existed in ILLiad past activity pages. This PR adds pagination to the remaining ILLiad pages.

> Last issue: with My Account.
> 
> When we were able to get her logged in to her account (xiaoxizh), she could see the first page of her interlibrary loan records (items 1-20 of 47) but the options at the bottom of that page to take her to the subsequent lists was unavailable. We confirmed with ILL that she does indeed have that many items checked out to her account. 

## Testing
* Run tests (`docker-compose run web bundle exec rspec`)
  * Break tests to make sure they work.
* Under `my_account.rb`, replace each ILLiad-related `session[:uniqname]` with `'xiaoxizh'`.
* Check all ILLiad pages to make sure they're not broken.