### PR TITLE
Empty State Image

### DIFF
--- a/css/_empty-state-container.scss
+++ b/css/_empty-state-container.scss
@@ -30,7 +30,8 @@
       margin-left: var(--space-xx-large);
     }
     .empty-state-image {
-      width: 35%;
+      max-width: 35%;
+      width: 100%;
     }
   }
 }


### PR DESCRIPTION
# Overview
> The empty state image layout and sizing is a little awkward when resizing the viewport. We should look at improving that layout at various screen sizes.

The image sizing was not consistent on desktop, and changed based on the length of the content. This PR fixes that and makes the size of the image the same throughout.

## Testing
* `npm run build-css`
* Check [Current Checkouts: Interlibrary Loan](http://localhost:4567/current-checkouts/interlibrary-loan) and [Current Checkouts: Scans and Electronic Items](http://localhost:4567/current-checkouts/scans-and-electronic-items) and see the image sizing remains the same. Check in Chrome, Firefox, and Safari.