### PR TITLE
[DAT-60] U-M Library Account | Light Evaluation

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -4,6 +4,7 @@
 (function () {
   const canClose = document.querySelectorAll('.can-close');
   canClose.forEach((close) => {
+    // Closing button
     const buttonsClose = close.querySelectorAll('.close-message');
     buttonsClose.forEach((buttonClose) => {
       buttonClose.addEventListener('click', (event) => {
@@ -11,6 +12,12 @@
         close.style.display = 'none';
       });
       buttonClose.disabled = false;
+    });
+    // Escape out of message
+    close.addEventListener('keyup', (event) => {
+      if (event.key === 'Escape') {
+        close.style.display = 'none';
+      }
     });
   });
 })();

--- a/js/modal.js
+++ b/js/modal.js
@@ -4,6 +4,9 @@ const modal = (attributeValue) => {
   const buttons = modal.querySelectorAll('button');
   buttons.forEach((button) => {
     button.disabled = false;
+    if (button.classList.contains('button--close')) {
+      button.focus();
+    }
   });
 };
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -32,8 +32,14 @@ updateHistoryButton.addEventListener('click', (event) => {
  * Force keyboard focus in modal
  */
 const getModal = document.getElementById(updateHistoryButton.getAttribute('data-js-modal'));
+const closeButton = getModal.querySelector('.button--close');
+const deleteHistoryButton = getModal.querySelector('[data-js-modal-button]');
+let previousFocus = false;
+document.addEventListener('keydown', (event) => {
+  previousFocus = event.shiftKey && event.key === 'Tab';
+});
 document.addEventListener('focusin', (event) => {
-  if (getModal.style.display === 'flex' && getModal.querySelectorAll(':focus').length === 0) {
-    getModal.querySelector('.button--close').focus();
+  if (getModal.style.display !== 'none' && !getModal.querySelectorAll(':focus').length) {
+    previousFocus ? deleteHistoryButton.focus() : closeButton.focus();
   }
 });

--- a/js/settings.js
+++ b/js/settings.js
@@ -27,3 +27,13 @@ updateHistoryButton.addEventListener('click', (event) => {
     modal(event.target.getAttribute('data-js-modal'));
   }
 });
+
+/**
+ * Force keyboard focus in modal
+ */
+const getModal = document.getElementById(updateHistoryButton.getAttribute('data-js-modal'));
+document.addEventListener('focusin', (event) => {
+  if (getModal.style.display === 'flex' && getModal.querySelectorAll(':focus').length === 0) {
+    getModal.querySelector('.button--close').focus();
+  }
+});


### PR DESCRIPTION
# Overview
The My Account team has [requested](https://tools.lib.umich.edu/jira/browse/DAT-60) the Digital Accessibility Team to do an [evaluation](https://docs.google.com/document/d/1Vk_2uJl8ImdO95UtWQTckrYMp1sbCWqzbC2HIDgU2SM/edit?usp=sharing) on the new My Account site. This branch resolves some of those issues.

## Keyboard
### Settings
> (Violation) When you select the radio button option, ‘No, do not keep my checkout history’ and then submit the ‘Update checkout history’ button in the ‘Settings page, the focus does not move to the dialog box (shown below). The keyboard order also allows people to move keyboard focus out of the dialog box to focusable elements within the page. This would be difficult and frustrating for keyboard users to know where the focus has gone (when the focus is hidden under the dialog box). 
Recommend moving keyboard focus to the ‘H3’ labelled ‘Delete checkout history’ or to the ‘cancel’ or ‘close’ button. Also recommend keeping keyboard within the focusable elements of the dialog box until it is closed, so people don’t get lost when focus moves outside focusable elements in the the dialog box.

JavaScript has been added that forces keyboard users to navigate only within the modal, until the modal has been closed.

## Testing
* Run tests to make sure they pass (`docker-compose run web bundle exec rspec`)
* Go through the site to make sure nothing is broken
* Navigate to [Settings](http://localhost:4567/settings)
  * Select `No, do not record my checkout history.` under `Checkout History`, and click `Update history preferences` to get the modal to show up.
  * See if the focus automatically shifts to the `X` (Close) button.
  * See if you can escape out of it.
  * See if you can navigate out of it by keyboard.