### PR TITLE
Build from ruby 2.7 instead of 2.7.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.2
+FROM ruby:2.7
 ARG UNAME=app
 ARG UID=1000
 ARG GID=1000

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM ruby:2.7.2
+FROM ruby:2.7
 ARG UNAME=app
 ARG UID=1000
 ARG GID=1000

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.2'
-
 gem 'sinatra'
 gem 'thin'
 gem 'httparty'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,8 +180,5 @@ DEPENDENCIES
   thin
   webmock
 
-RUBY VERSION
-   ruby 2.7.2p137
-
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
I'm not sure whether this will work or even do what I hope it will do. My hope is that, by building from ruby 2.7 instead of 2.7.2, the testing deployment will start using 2.7.4. If that works, then all anyone will have to do when there's a new ruby minor version is simply rebuild their container image without needing to change the code at all.

I don't know if this will break development, by removing the ruby version from the gemfile. Bundle install ran ok for me, but I don't have a working development environment, so I had no way to test it. So it'd probably be a good idea to check that before merging this. Probably you'll have to run `docker pull ruby:2.7` to make sure you've got the latest base image.

I see you run tests before building images, which is awesome. If this does work, then if a new minor version ever doesn't pass for whatever reason, nothing will break, because there won't be anything new to deploy.