### PR TITLE
[DAT-60] Headings

### DIFF
--- a/css/_base.scss
+++ b/css/_base.scss
@@ -89,7 +89,8 @@ h2,
   line-height: auto;
 }
 
-h3 {
+h3,
+.h3 {
   font-size: var(--text-medium);
   font-weight: var(--semibold);
 }

--- a/lib/entities/empty_state.rb
+++ b/lib/entities/empty_state.rb
@@ -1,8 +1,9 @@
 class Entities::Page::EmptyState
-  attr_reader :heading, :message
+  attr_reader :heading, :message, :heading_tag
   def initialize(empty_state, parent_empty_state=nil)
     @heading = "You have no items."
     @message = "See <a href=\"https://www.lib.umich.edu/find-borrow-request\">what you can borrow from the library<\/a>."
+    @heading_tag = "h3"
     
     if !empty_state.nil?
       @heading = empty_state["heading"] || @heading
@@ -10,6 +11,10 @@ class Entities::Page::EmptyState
     elsif !parent_empty_state.nil?
       @heading = parent_empty_state.heading || @heading
       @message = parent_empty_state.message || @message
+    end
+
+    if parent_empty_state.nil?
+      @heading_tag = "h2"
     end
   end
 end

--- a/spec/lib/entities/empty_state_spec.rb
+++ b/spec/lib/entities/empty_state_spec.rb
@@ -23,7 +23,7 @@ describe Entities::Page::EmptyState do
     expect(subject.heading_tag).to eq(parentless_heading_tag)
   end
   it "if nil, uses parent if available" do
-    @parent_empty_state = described_class.new({"heading" => "Parent Heading", "message" => "Parent Message", "heading_tag" => "h3"}, nil)
+    @parent_empty_state = described_class.new({"heading" => "Parent Heading", "message" => "Parent Message"}, nil)
     @empty_state = nil
     expect(subject.heading).to eq("Parent Heading")
     expect(subject.message).to eq("Parent Message")

--- a/spec/lib/entities/empty_state_spec.rb
+++ b/spec/lib/entities/empty_state_spec.rb
@@ -1,6 +1,8 @@
 describe Entities::Page::EmptyState do
   let(:default_heading){'You have no items.'}
   let(:default_message){ "See <a href=\"https://www.lib.umich.edu/find-borrow-request\">what you can borrow from the library<\/a>."}
+  let(:default_heading_tag){"h3"}
+  let(:parentless_heading_tag){ "h2"}
                       
   before(:each) do
     @empty_state = { "heading" => 'This is a heading', "message" => 'This is a message.' }
@@ -10,23 +12,42 @@ describe Entities::Page::EmptyState do
     described_class.new(@empty_state, @parent_empty_state)
   end
   it "handles given empty state" do
-    expect(subject.heading) == @empty_state["heading"]
-    expect(subject.message) == @empty_state["message"]
+    expect(subject.heading).to eq(@empty_state["heading"])
+    expect(subject.message).to eq(@empty_state["message"])
+    expect(subject.heading_tag).to eq(parentless_heading_tag)
   end
-  it "handles  nil both" do
+  it "handles nil both" do
     @empty_state = nil
-    expect(subject.heading) == default_heading
-    expect(subject.message) == default_message
+    expect(subject.heading).to eq(default_heading)
+    expect(subject.message).to eq(default_message)
+    expect(subject.heading_tag).to eq(parentless_heading_tag)
   end
   it "if nil, uses parent if available" do
-    @parent_empty_state = described_class.new({"heading" => "Parent Heading", "message" => "Parent Message"}, nil)
+    @parent_empty_state = described_class.new({"heading" => "Parent Heading", "message" => "Parent Message", "heading_tag" => "h3"}, nil)
     @empty_state = nil
     expect(subject.heading).to eq("Parent Heading")
     expect(subject.message).to eq("Parent Message")
+    expect(subject.heading_tag).to eq(default_heading_tag)
   end
   it "uses default if one is missing" do
     @empty_state.delete("message")
-    expect(subject.heading) == @empty_state["heading"]
-    expect(subject.message) == default_message
+    expect(subject.heading).to eq(@empty_state["heading"])
+    expect(subject.message).to eq(default_message)
+    expect(subject.heading_tag).to eq(parentless_heading_tag)
+  end
+  it "uses default if two are missing" do
+    @empty_state.delete("heading")
+    @empty_state.delete("message")
+    expect(subject.heading).to eq(default_heading)
+    expect(subject.message).to eq(default_message)
+    expect(subject.heading_tag).to eq(parentless_heading_tag)
+  end
+  it "if no parent, `heading_tag` changes to `h2`" do
+    @parent_empty_state = nil
+    expect(subject.heading_tag).to eq(parentless_heading_tag)
+  end
+  it "if parent exists, `heading_tag` changes to `h3`" do
+    @parent_empty_state = {}
+    expect(subject.heading_tag).to eq(default_heading_tag)
   end
 end

--- a/views/empty_state.erb
+++ b/views/empty_state.erb
@@ -1,10 +1,15 @@
 <%
-  empty_state = Entities::Pages.page(request.path_info).empty_state
+  page = Entities::Pages.page(request.path_info)
+  empty_state = page.empty_state
 %>
 
 <section class="empty-state-container">
   <div class="empty-state-content owl">
-    <h3><%=empty_state.heading%></h3>
+    <% if page.parent.nil? %>
+      <h2 class="h3"><%=empty_state.heading%></h2>
+    <% else %>
+      <h3><%=empty_state.heading%></h3>
+    <% end %>
     <p><%=empty_state.message%></p>
   </div>
 

--- a/views/empty_state.erb
+++ b/views/empty_state.erb
@@ -1,15 +1,12 @@
 <%
-  page = Entities::Pages.page(request.path_info)
-  empty_state = page.empty_state
+  empty_state = Entities::Pages.page(request.path_info).empty_state
 %>
 
 <section class="empty-state-container">
   <div class="empty-state-content owl">
-    <% if page.parent.nil? %>
-      <h2 class="h3"><%=empty_state.heading%></h2>
-    <% else %>
-      <h3><%=empty_state.heading%></h3>
-    <% end %>
+    <<%=empty_state.heading_tag%> class="h3">
+      <%=empty_state.heading%>
+    </<%=empty_state.heading_tag%>>
     <p><%=empty_state.message%></p>
   </div>
 


### PR DESCRIPTION
# Overview
Some pages with empty states had a skipped heading, going from `h1` to `h3`. The only one I found was in [Fines and Fees](http://localhost:4567/fines-and-fees). This PR creates a check to see if the current page that the empty state is on does not have a parent. If no parent, the heading gets changed from an `h3` to an `h2`, but styled like an `h3`.

Resolves #210.

## Testing
* Run tests to make sure they pass (`docker-compose run web bundle exec rspec`)
* Go through the site to make sure nothing is broken
* Navigate to [Fines and Fees](http://localhost:4567/fines-and-fees) to see if the empty state shows up.
  * `Inspect Element` to make sure the heading is an `h2`.