### PR TITLE
started claims returned

### DIFF
--- a/models/items/alma/loans.rb
+++ b/models/items/alma/loans.rb
@@ -77,7 +77,7 @@ class Loan < AlmaItem
     client.post("/users/#{uniqname}/loans/#{loan_id}", query: {op: 'renew'})
   end
   def due_date
-    DateTime.patron_format(@parsed_response["due_date"])
+    DateTime.patron_format(@parsed_response["due_date"]) unless claims_returned?
   end
   def renewable?
     !!@parsed_response["renewable"] #make this a real boolean
@@ -95,6 +95,11 @@ class Loan < AlmaItem
     @parsed_response["publication_year"]
   end
   def due_status
+    return "Reported as returned" if claims_returned?
     LoanDate.parse(@parsed_response["due_date"]).due_status
+  end
+  private
+  def claims_returned?
+    @parsed_response["process_status"]=="CLAIMED_RETURN"
   end
 end

--- a/spec/fixtures/claims_returned.json
+++ b/spec/fixtures/claims_returned.json
@@ -1,0 +1,50 @@
+{
+    "item_loan": [
+      {
+        "loan_id": "21174281390006381",
+        "circ_desk": {
+          "value": "DEFAULT_CIRC_DESK",
+          "desc": "North Information Desk"
+        },
+        "return_circ_desk": {
+          "value": null,
+          "desc": null,
+          "link": null
+        },
+        "library": {
+          "value": "HATCH",
+          "desc": "Hatcher Graduate"
+        },
+        "user_id": "mlibrary.acct.testing1@gmail.com",
+        "item_barcode": "A35473",
+        "due_date": "2022-03-09T04:59:00Z",
+        "loan_status": "ACTIVE",
+        "loan_date": "2022-03-08T14:47:07.839Z",
+        "returned_by": {
+          "value": "",
+          "link": null
+        },
+        "process_status": "CLAIMED_RETURN",
+        "mms_id": "99187521361606381",
+        "holding_id": "221181038150006381",
+        "item_id": "231181038130006381",
+        "title": "Journal of Cats",
+        "author": null,
+        "description": null,
+        "location_code": {
+          "value": "GRAD",
+          "name": "GRAD"
+        },
+        "item_policy": {
+          "value": null,
+          "description": null
+        },
+        "renewable": null,
+        "last_renew_status": {
+          "value": null,
+          "desc": ""
+        }
+      }
+    ],
+    "total_record_count": 1
+  }

--- a/spec/models/items/alma/loans_spec.rb
+++ b/spec/models/items/alma/loans_spec.rb
@@ -157,6 +157,10 @@ describe Loan do
     it "returns due date string" do
       expect(subject.due_date).to eq("07/08/18")
     end
+    it "returns nothing when claims returned" do
+      @loan_response = JSON.parse(File.read("./spec/fixtures/claims_returned.json"))["item_loan"][0]
+      expect(subject.due_date).to eq(nil)
+    end
   end
   context "#due_status" do
     it "returns 'Overdue'" do
@@ -170,6 +174,10 @@ describe Loan do
     it "returns 'Due Soon' for 7 days" do
       @loan_response["due_date"] = (Date.today + 7).strftime("%FT%H:%M:%SZ")
       expect(subject.due_status).to eq("Due Soon")
+    end
+    it "returns reported as returned for claims returned" do
+      @loan_response = JSON.parse(File.read("./spec/fixtures/claims_returned.json"))["item_loan"][0]
+      expect(subject.due_status).to eq('Reported as returned')
     end
     it "returns empty string for far away dates" do
       @loan_response["due_date"] = (Date.today + 8).strftime("%FT%H:%M:%SZ")


### PR DESCRIPTION


# Problem Statement

Users are confused when they claim they have returned an item, but Account continue to shows it as checked out.

# Success Criteria

Catalog items with the Alma status "Claims Returned" display in the users's Account Checkouts as follows:

* A status of “Reported as returned” with warning (yellow) background color
* No "Renew" button

