### PR TITLE
rolling back to earlier omniauth and openid_connect gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ gem "sinatra-flash"
 gem "telephone_number"
 gem "jwt"
 gem "addressable"
-gem "omniauth"
-gem "omniauth_openid_connect"
+gem "omniauth", "~>1.9"
+gem "omniauth_openid_connect", "~>0.3.5"
 gem "redcarpet"
 
 # In order to get rspec to work for ruby 3.1. Maybe later see if it's still necessary

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,13 +68,12 @@ GEM
       digest
       net-protocol
       timeout
-    omniauth (2.0.4)
+    omniauth (1.9.1)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
-      rack-protection
-    omniauth_openid_connect (0.4.0)
+    omniauth_openid_connect (0.3.5)
       addressable (~> 2.5)
-      omniauth (>= 1.9, < 3)
+      omniauth (~> 1.9)
       openid_connect (~> 1.1)
     openid_connect (1.3.0)
       activemodel
@@ -200,8 +199,8 @@ DEPENDENCIES
   httparty
   jwt
   net-smtp
-  omniauth
-  omniauth_openid_connect
+  omniauth (~> 1.9)
+  omniauth_openid_connect (~> 0.3.5)
   pry
   pry-byebug
   rack-test


### PR DESCRIPTION
Latest Omniauth and openid connect gems wasn't working in testing and staging. Rolled back to the older ones.