### PR TITLE
[LIBSEARCH-709] Authentication handling for Account and Media Booking

### DIFF
--- a/account.rb
+++ b/account.rb
@@ -102,20 +102,7 @@ get "/logout" do
 end
 
 get "/login" do
-  <<~HTML
-    <h1>Logging You In...<h1>
-    <script>
-      window.onload = function(){
-        document.forms['login_form'].submit();
-      }
-    </script>
-    <form id='login_form' method='post' action='/auth/openid_connect'>
-      <input type="hidden" name="authenticity_token" value='#{request.env["rack.session"]["csrf"]}'>
-      <noscript>
-        <button type="submit">Login</button>
-      </noscript>
-    </form>
-  HTML
+  erb :'login/index', locals: {has_js: true}
 end
 
 before do

--- a/config/navigation.json
+++ b/config/navigation.json
@@ -132,6 +132,7 @@
   },
   {
     "title": "Login",
-    "icon_name": "person-outline"
+    "icon_name": "person-outline",
+    "sidebar": "false"
   }
 ]

--- a/config/navigation.json
+++ b/config/navigation.json
@@ -131,8 +131,9 @@
     "dropdown": "true"
   },
   {
-    "title": "Login",
+    "title": "Logging you in...",
     "icon_name": "person-outline",
-    "sidebar": "false"
+    "sidebar": "false",
+    "slug": "login"
   }
 ]

--- a/config/navigation.json
+++ b/config/navigation.json
@@ -129,5 +129,9 @@
     "icon_name": "settings",
     "color": "green",
     "dropdown": "true"
+  },
+  {
+    "title": "Login",
+    "icon_name": "person-outline"
   }
 ]

--- a/js/login.js
+++ b/js/login.js
@@ -1,0 +1,3 @@
+window.onload = () => {
+  document.getElementById('login-form').submit();
+};

--- a/lib/entities/pages.rb
+++ b/lib/entities/pages.rb
@@ -30,7 +30,7 @@ class Entities::Page
     @parent = parent
     @children = page.dig("children")&.map { |p| Entities::Page.new(p, self) }
   end
-  ["title", "description", "icon_name", "color", "dropdown"].each do |name|
+  ["title", "description", "icon_name", "color", "dropdown", "sidebar"].each do |name|
     define_method(name) do
       @page[name]
     end

--- a/lib/entities/pages.rb
+++ b/lib/entities/pages.rb
@@ -54,6 +54,8 @@ class Entities::Page
   def slug
     if title == "Account Overview"
       ""
+    elsif @page["slug"]
+      @page["slug"]
     else
       title.gsub("/", "or").gsub("&", "and").gsub(/\s/, "-").downcase
     end

--- a/lib/navigation/sidebar.rb
+++ b/lib/navigation/sidebar.rb
@@ -1,8 +1,8 @@
 class Navigation::Sidebar < Navigation
   attr_reader :pages
   def initialize(active_page)
-    @pages = Entities::Pages.all.map do |page|
-      pick_page(active_page: active_page, current_page: page)
+    @pages = Entities::Pages.all.filter_map do |page|
+      pick_page(active_page: active_page, current_page: page) if page.sidebar != "false"
     end
   end
 end

--- a/spec/lib/entities/pages_spec.rb
+++ b/spec/lib/entities/pages_spec.rb
@@ -11,7 +11,8 @@ describe Entities::Page do
       "icon_name" => "icon_name",
       "color" => "color",
       "empty_state" => nil,
-      "dropdown" => "dropdown"
+      "dropdown" => "dropdown",
+      "sidebar" => "sidebar"
     }
     @parent = nil
   end
@@ -20,7 +21,7 @@ describe Entities::Page do
     described_class.new(@page, @parent)
   end
 
-  ["title", "description", "icon_name", "color", "dropdown"].each do |method|
+  ["title", "description", "icon_name", "color", "dropdown", "sidebar"].each do |method|
     context "##{method}" do
       it "returns a string" do
         expect(subject.public_send(method)).to eq(method)

--- a/spec/lib/entities/pages_spec.rb
+++ b/spec/lib/entities/pages_spec.rb
@@ -59,5 +59,10 @@ describe Entities::Page do
       @page["title"] = "Account Overview"
       expect(subject.slug).to eq("")
     end
+    it "overrides the slug if predefined" do
+      @page["title"] = "Logging you in..."
+      @page["slug"] = "login"
+      expect(subject.slug).to eq("login")
+    end
   end
 end

--- a/spec/lib/navigation/sidebar_spec.rb
+++ b/spec/lib/navigation/sidebar_spec.rb
@@ -3,7 +3,7 @@ describe Navigation::Sidebar do
     subject do
       described_class.for("/")
     end
-    it "has pages all top-level pages" do
+    it "has pages all top-level pages that are not hidden from the sidebar" do
       expect(subject.pages.count).to eq(7)
     end
     it "has correct active page" do

--- a/views/layout/user_drop_down.erb
+++ b/views/layout/user_drop_down.erb
@@ -1,23 +1,25 @@
 <% dropdown = Navigation::UserDropdown.for(request.path_info) %>
 
-<nav class="user-navigation dropdown" aria-label="User Dropdown Navigation">
-  <button aria-expanded="false" data-dropdown="user-nav-dropdown" class="button--dropdown">
-    <m-icon name="person-outline"></m-icon>
-    <span><%=session[:uniqname]%></span>
-    <m-icon name="keyboard-arrow-down"></m-icon>
-  </button>
-  <div class="navigation-lists dropdown-container" id="user-nav-dropdown" style="display: none;">
-    <ul class="site-navigation-list">
-      <% dropdown.pages.each do |page| %>
-        <li class="<%= page.active %>">
-          <a href="<%=page.path%>" <% if page.active? %>aria-current="page"<% end %>>
-            <span><%=page.title%></span>
-          </a>
-        </li>
-      <% end %>
-    </ul>
-    <a href="/logout">
-      <span>Log out</span>
-    </a>
-  </div>
-</nav>
+<% if session[:uniqname] %>
+  <nav class="user-navigation dropdown" aria-label="User Dropdown Navigation">
+    <button aria-expanded="false" data-dropdown="user-nav-dropdown" class="button--dropdown">
+      <m-icon name="person-outline"></m-icon>
+      <span><%=session[:uniqname]%></span>
+      <m-icon name="keyboard-arrow-down"></m-icon>
+    </button>
+    <div class="navigation-lists dropdown-container" id="user-nav-dropdown" style="display: none;">
+      <ul class="site-navigation-list">
+        <% dropdown.pages.each do |page| %>
+          <li class="<%= page.active %>">
+            <a href="<%=page.path%>" <% if page.active? %>aria-current="page"<% end %>>
+              <span><%=page.title%></span>
+            </a>
+          </li>
+        <% end %>
+      </ul>
+      <a href="/logout">
+        <span>Log out</span>
+      </a>
+    </div>
+  </nav>
+<% end %>

--- a/views/login/index.erb
+++ b/views/login/index.erb
@@ -1,4 +1,4 @@
-<h2>Redirecting...</h2>
+<p>You will be redirected to your account shortly.</p>
 <form id="login-form" method="post" action="/auth/openid_connect">
   <input type="hidden" name="authenticity_token" value="<%= request.env["rack.session"]["csrf"] %>">
   <noscript>

--- a/views/login/index.erb
+++ b/views/login/index.erb
@@ -1,0 +1,7 @@
+<h2>Redirecting...</h2>
+<form id="login-form" method="post" action="/auth/openid_connect">
+  <input type="hidden" name="authenticity_token" value="<%= request.env["rack.session"]["csrf"] %>">
+  <noscript>
+    <button type="submit">Login</button>
+  </noscript>
+</form>

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -5,7 +5,8 @@ module.exports = {
   entry: {
     main: './js/index.js',
     'current-checkouts-u-m-library': './js/current-checkouts.js',
-    settings: './js/settings.js'
+    settings: './js/settings.js',
+    login: './js/login.js'
   },
   output: {
     filename: '[name].bundle.js',


### PR DESCRIPTION
# Overview
A login page has been added for authentication. The page needs to be styled to include the site's layout.

This pull request closes [LIBSEARCH-709](https://mlit.atlassian.net/browse/LIBSEARCH-709).

## Testing
- [ ] Run the tests to make sure they pass (`docker-compose run web bundle exec rspec`).
  - [ ] Break the new/updated unit tests to make sure they're working properly.
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- [ ] Check out [Account](http://localhost:4567/), and see if you're redirected to the [login](http://localhost:4567/login) page
  - [ ] Does a styled page appear, saying that it's redirecting?
    - [ ] Do you see the user dropdown on the site?
  - [ ] Are you taken to U-M Weblogin?
  - [ ] Are you redirected back to the [home](http://localhost:4567/) page after logging in?
  - [ ] Can you navigate throughout the site without being redirected back to the login page?