### PR TITLE
Disable rackup

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -38,4 +38,4 @@ RUN npm ci
 RUN npm run build-css
 RUN npm run build-js
 
-CMD ["bundle", "exec", "rackup", "-p", "4567", "--host", "0.0.0.0"]
+CMD ["bundle", "exec", "ruby", "account.rb", "-o", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,10 +16,9 @@ services:
     command:
       - bundle 
       - exec 
-      - rackup 
-      - -p
-      - "4567"
-      - --host
+      - ruby
+      - account.rb
+      - -o
       - 0.0.0.0
         
   nelnet-test:

--- a/nelnet_test/Gemfile.lock
+++ b/nelnet_test/Gemfile.lock
@@ -1,28 +1,28 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     multi_json (1.15.0)
-    mustermann (1.1.1)
+    mustermann (2.0.2)
       ruby2_keywords (~> 0.0.1)
-    public_suffix (4.0.6)
-    rack (2.2.3)
-    rack-protection (2.2.0)
+    public_suffix (5.0.0)
+    rack (2.2.4)
+    rack-protection (2.2.2)
       rack
     ruby2_keywords (0.0.5)
-    sinatra (2.2.0)
-      mustermann (~> 1.0)
+    sinatra (2.2.2)
+      mustermann (~> 2.0)
       rack (~> 2.2)
-      rack-protection (= 2.2.0)
+      rack-protection (= 2.2.2)
       tilt (~> 2.0)
-    sinatra-contrib (2.2.0)
+    sinatra-contrib (2.2.2)
       multi_json
-      mustermann (~> 1.0)
-      rack-protection (= 2.2.0)
-      sinatra (= 2.2.0)
+      mustermann (~> 2.0)
+      rack-protection (= 2.2.2)
+      sinatra (= 2.2.2)
       tilt (~> 2.0)
-    tilt (2.0.10)
+    tilt (2.0.11)
 
 PLATFORMS
   ruby

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,7 @@ require "webmock/rspec"
 require "simplecov"
 require "climate_control"
 SimpleCov.start
-ENV["RACK_ENV"] = "test"
+ENV["APP_ENV"] = "test"
 
 require File.expand_path "../../account.rb", __FILE__
 OmniAuth.config.test_mode = true


### PR DESCRIPTION
Goes back to using `ruby account.rb` to start up account. This is because the [threading setting can't be sent to thin through rackup](https://stackoverflow.com/questions/17570301/sinatra-with-thin-multi-thread-do-not-work).

This also updates `rack` in nelnet_test to get rid of the dependabot warning. 

 