### PR TITLE
[LIBSEARCH-814] ACCOUNT: Remove "Favorites" from Account navigation

### DIFF
--- a/config/navigation.json
+++ b/config/navigation.json
@@ -114,16 +114,6 @@
     }
   },
   {
-    "title": "Favorites",
-    "description": "View items you've added to your favorites.",
-    "icon_name": "star",
-    "color": "maize",
-    "empty_state": {
-      "heading": "You haven't added any favorites.",
-      "message": "You can save items to appear here by selecting “Save to Favorites” when viewing an item record in <a href=\"https://search.lib.umich.edu/everything?query=&utm_source=lib-home\">Library Search</a>."
-    }
-  },
-  {
     "title": "Settings",
     "description": "Review your contact information and update your account preferences.",
     "icon_name": "settings",

--- a/lib/navigation/navigation.rb
+++ b/lib/navigation/navigation.rb
@@ -1,6 +1,6 @@
 class Navigation
   def self.cards
-    Entities::Pages.all[1, 6]
+    Entities::Pages.all[1, 5]
   end
 
   def self.home

--- a/spec/lib/navigation/navigation_spec.rb
+++ b/spec/lib/navigation/navigation_spec.rb
@@ -7,7 +7,7 @@ describe Navigation do
       expect(subject.find { |x| x.title == "Account Overview" }).to be_nil
     end
     it "should have 6 elements" do
-      expect(subject.count).to eq(6)
+      expect(subject.count).to eq(5)
     end
   end
   context ".home" do

--- a/spec/lib/navigation/sidebar_spec.rb
+++ b/spec/lib/navigation/sidebar_spec.rb
@@ -4,7 +4,7 @@ describe Navigation::Sidebar do
       described_class.for("/")
     end
     it "has pages all top-level pages that are not hidden from the sidebar" do
-      expect(subject.pages.count).to eq(7)
+      expect(subject.pages.count).to eq(6)
     end
     it "has correct active page" do
       expect(subject.pages.first.active?).to eq(true)


### PR DESCRIPTION
# Overview
> As part of the Favorites Decommissioning, remove 
”My Favorites” from the top of all pages in https://account.lib.umich.edu/. 
>
> * Remove from left-side navigation
> * Remove tile from landing page (possibly keep it, inactive, with an explanation, pending review of Account analytics)

This pull request closes [LIBSEARCH-814](https://mlit.atlassian.net/browse/LIBSEARCH-814).

## Testing
- Run the tests to make sure they pass (`docker-compose run --rm web bundle exec rspec`).
  - Break the new/updated unit tests to make sure they're working properly.
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari
  - [ ] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Check and see if `Favorites` shows up in the sidebar or in `Account Overview`.
