### PR TITLE
fix: normalizes the request status

### DIFF
--- a/models/items/alma/requests.rb
+++ b/models/items/alma/requests.rb
@@ -48,12 +48,14 @@ class Request < AlmaItem
   end
 
   def status
-    case @parsed_response["request_status"]
-    when "In Process"
+    request_status = @parsed_response["request_status"] || ""
+    normalized_status = request_status.upcase.tr(" ", "_")
+    case normalized_status
+    when "IN_PROCESS"
       "In process"
-    when "On Hold Shelf"
+    when "ON_HOLD_SHELF"
       "Ready"
-    when "Not Started"
+    when "NOT_STARTED"
       "Not started"
     else
       ""

--- a/spec/models/items/alma/requests_spec.rb
+++ b/spec/models/items/alma/requests_spec.rb
@@ -98,7 +98,17 @@ describe HoldRequest do
     end
   end
   context "#status" do
+    # both of these are here because the Alma API isn't consistent with
+    # what is returned for "request_status"
+    it "returns 'In process' when In Process" do
+      expect(subject.status).to eq("In process")
+    end
+    it "handles nil request status" do
+      @hold_response["request_status"] = nil
+      expect(subject.status).to eq("")
+    end
     it "returns 'In process' when IN_PROCESS" do
+      @hold_response["request_status"] = "IN_PROCESS"
       expect(subject.status).to eq("In process")
     end
   end


### PR DESCRIPTION
# Overview
This deals with ExLibris changing the values of "request_status" in the requests API.

This pull request fixes [LIBSEARCH-826](https://mlit.atlassian.net/browse/LIBSEARCH-826).