### PR TITLE
LIBESEARCH-69 removes warning about enum-cron data

### DIFF
--- a/views/current-checkouts/u-m-library.erb
+++ b/views/current-checkouts/u-m-library.erb
@@ -4,10 +4,6 @@
 
 <% elsif %>
 
-<m-callout subtle icon>
-  <p>Items checked out prior to <time datetime="2021-07-15">July 15, 2021</time> might not display details such as volume or edition. If you have a question or need help with renewals, please contact the <a href="https://lib.umich.edu/locations-and-hours/hatcher-library/hatcher-north-information-services-desk">Hatcher North Information Services Desk</a>.</p>
-</m-callout>
-
 <% unless message.nil? %>
   <%= erb :'current-checkouts/_message-callout', locals: {message: message} %>
 <% end %>


### PR DESCRIPTION
# Overview

This pull request resolves [LIBSEARCH-69](https://mlit.atlassian.net/browse/LIBSEARCH-69).

It removes the warning about enum-cron data potentially being missing from checkouts from before the Alma migration.
