### PR TITLE
LIBSEARCH-882

### DIFF
--- a/models/items/circ_history/circ_history_item.rb
+++ b/models/items/circ_history/circ_history_item.rb
@@ -38,8 +38,7 @@ end
 
 class CirculationHistoryItem < Item
   def url
-    doc_id = mms_id.slice(2, 9)
-    "https://search.lib.umich.edu/catalog/record/#{doc_id}"
+    "https://search.lib.umich.edu/catalog/record/#{mms_id}"
   end
 
   def call_number

--- a/spec/models/items/circ_history/past_loans_spec.rb
+++ b/spec/models/items/circ_history/past_loans_spec.rb
@@ -70,7 +70,7 @@ describe CirculationHistoryItem do
     described_class.new(loans["loans"][0])
   end
   it "has expected url" do
-    expect(subject.url).to eq("https://search.lib.umich.edu/catalog/record/000546765")
+    expect(subject.url).to eq("https://search.lib.umich.edu/catalog/record/990005467650206381")
   end
   it "responds to barcode" do
     expect(subject.barcode).to eq("39015061357532")


### PR DESCRIPTION
# Overview
checkout history used to link back to catalog records in search with the the 9 digit aleph id. At this point it should use the full mms_id. This PR fixes that.

This pull request fixes [LIBSEARCH-882](https://mlit.atlassian.net/browse/LIBSEARCH-882).
