### PR TITLE
Warning about SMS messages

### DIFF
--- a/views/settings/index.erb
+++ b/views/settings/index.erb
@@ -40,6 +40,9 @@
 
     <form class="owl" method="post" action="/sms">
       <h2>Text Notifications</h2>
+      <m-callout subtle icon variant="warning">
+      <p>Texting notifications to your mobile device is temporarily unavailable. You can still submit your phone number and when this functionality is restored you will receive messages at your submitted number.</p>
+      </m-callout>
 
       <p>Add a phone number to receive text notifications on the status of your request and loans. Special collections requests are not included. Message and data rates may apply.</p>
 


### PR DESCRIPTION
Due to problems with Twilio configuration SMS messages are currently not working. This PR adds a message about it in settings. 