### PR TITLE
current-checkouts doesn't have js anymore

### DIFF
--- a/lib/routes/current_checkouts.rb
+++ b/lib/routes/current_checkouts.rb
@@ -12,7 +12,7 @@ namespace "/current-checkouts" do
     loan_controls = TableControls::LoansForm.new(limit: params["limit"], order_by: params["order_by"], direction: params["direction"])
     loans = Loans.for(uniqname: session[:uniqname], offset: params["offset"], limit: params["limit"], order_by: params["order_by"], direction: params["direction"])
     message = session.delete(:message)
-    erb :"current-checkouts/u-m-library", locals: {loans: loans, message: message, loan_controls: loan_controls, has_js: true}
+    erb :"current-checkouts/u-m-library", locals: {loans: loans, message: message, loan_controls: loan_controls}
   rescue => e
     flash.now[:error] = "<span class='strong'>Error:</span> We were unable to load your loans. Please try again." unless e.message == "not_in_alma"
     erb :empty_state

--- a/spec/requests/current_checkouts_spec.rb
+++ b/spec/requests/current_checkouts_spec.rb
@@ -41,10 +41,6 @@ describe "current-checkouts requests" do
         get "/current-checkouts/u-m-library"
         expect(last_response.body).to include("U-M Library")
       end
-      it "has checkouts js" do
-        get "/current-checkouts/u-m-library"
-        expect(last_response.body).to include("current-checkouts-u-m-library.bundle.js")
-      end
     end
     context "in alma user but alma has a network problem" do
       it "loads the empty state and has an error flash" do


### PR DESCRIPTION
# Overview
In checking the design-system updates, I saw an error on current checkouts because it was still trying to load the JS that was removed a while ago. This change fixes that problem.
