### PR TITLE
fixing receipt to return an Error when the payment has been declined

### DIFF
--- a/models/fines/receipt.rb
+++ b/models/fines/receipt.rb
@@ -11,31 +11,34 @@ class Receipt
 
   def self.for(uniqname:, nelnet_params:, order_number:, is_valid: Nelnet.verify(nelnet_params))
     payment = Payment.new(nelnet_params)
-    if is_valid
-      payment_verification = Fines.verify_payment(uniqname: uniqname, order_number: order_number)
-      if payment_verification.instance_of?(AlmaError)
-        S.logger.error("Fine payment error: order_number: #{payment.order_number}; message: #{payment_verification.message}")
-        ErrorReceipt.new("There was an error in processing your payment.<br>Your payment order number is: #{payment.order_number}<br>Server error: #{payment_verification.message}</br>")
-      elsif payment_verification[:has_order_number]
-        S.logger.error("Fine payment error: order number #{order_number} is already in Alma.")
-        ErrorReceipt.new("Your payment order number, #{order_number}, is already in the fines database.")
-      elsif payment_verification[:total_sum].to_f.to_s == "0.0"
-        S.logger.error("Fine payment error: order number #{order_number} tried to pay $0.00")
-        ErrorReceipt.new("You do not have a balance. Your payment order number is: #{order_number}.")
-      else # has not already paid
-        resp = Fines.pay(uniqname: uniqname, amount: payment.amount, order_number: order_number)
-        if resp.code != 200
-          error = AlmaError.new(resp)
-          S.logger.error("Fine payment error: order number #{order_number}; message: #{error.message}")
-          ErrorReceipt.new("#{error.message}<br>Your payment order number is: #{order_number}")
-        else
-          S.logger.info("Fine payment success")
-          Receipt.new(payment: payment, balance: resp.parsed_response["total_sum"])
-        end
-      end
-    else # not valid
+    if !is_valid
       S.logger.error("Fine payment error: order number #{order_number} payment could not be validated.")
-      ErrorReceipt.new("Your payment could not be validated. Your payment order number is: #{payment.order_number}")
+      return ErrorReceipt.new("Your payment could not be validated. Your payment order number is: #{payment.order_number}")
+    end
+    if !/Approved/.match?(nelnet_params["transactionResultMessage"])
+      return ErrorReceipt.new("There was an error processing your payment.<br/>The error message is: #{nelnet_params["transactionResultMessage"]}<br/>Your payment order number is: #{order_number}")
+    end
+
+    payment_verification = Fines.verify_payment(uniqname: uniqname, order_number: order_number)
+    if payment_verification.instance_of?(AlmaError)
+      S.logger.error("Fine payment error: order_number: #{payment.order_number}; message: #{payment_verification.message}")
+      ErrorReceipt.new("There was an error in processing your payment.<br>Your payment order number is: #{payment.order_number}<br>Server error: #{payment_verification.message}</br>")
+    elsif payment_verification[:has_order_number]
+      S.logger.error("Fine payment error: order number #{order_number} is already in Alma.")
+      ErrorReceipt.new("Your payment order number, #{order_number}, is already in the fines database.")
+    elsif payment_verification[:total_sum].to_f.to_s == "0.0"
+      S.logger.error("Fine payment error: order number #{order_number} tried to pay $0.00")
+      ErrorReceipt.new("You do not have a balance. Your payment order number is: #{order_number}.")
+    else # has not already paid
+      resp = Fines.pay(uniqname: uniqname, amount: payment.amount, order_number: order_number)
+      if resp.code != 200
+        error = AlmaError.new(resp)
+        S.logger.error("Fine payment error: order number #{order_number}; message: #{error.message}")
+        ErrorReceipt.new("#{error.message}<br>Your payment order number is: #{order_number}")
+      else
+        S.logger.info("Fine payment success")
+        Receipt.new(payment: payment, balance: resp.parsed_response["total_sum"])
+      end
     end
   end
 

--- a/spec/models/fines/receipt_spec.rb
+++ b/spec/models/fines/receipt_spec.rb
@@ -69,6 +69,11 @@ describe Receipt, ".for" do
     expect(subject.class.name).to eq("ErrorReceipt")
     expect(subject.message).to include("balance")
   end
+  it "returns ErrorReceipt if transactionResultMessage is not Approved" do
+    @params["transactionResultMessage"] = "Declined"
+    expect(subject.class.name).to eq("ErrorReceipt")
+    expect(subject.message).to include("Declined")
+  end
 end
 describe Payment do
   before(:each) do


### PR DESCRIPTION
This wasn't set to handle non-successful payments in Nelnet. Now it is. A declined message payment looks like this:
![image](https://github.com/user-attachments/assets/84137dc9-1d2b-4f03-8bb5-47406de06670)
