### PR TITLE
adds ostruct to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "rackup"
 gem "canister"
 gem "semantic_logger"
 gem "csv" # included here because httparty uses it and ought to require it
+gem "ostruct"
 
 # In order to get rspec to work for ruby 3.1. Maybe later see if it's still necessary
 gem "net-smtp", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,7 @@ GEM
       tzinfo
       validate_url
       webfinger (~> 2.0)
+    ostruct (0.6.0)
     parallel (1.26.3)
     parser (3.3.5.0)
       ast (~> 2.4.1)
@@ -282,6 +283,7 @@ DEPENDENCIES
   net-smtp
   omniauth
   omniauth_openid_connect
+  ostruct
   pry
   pry-byebug
   puma


### PR DESCRIPTION
Add ostruct to Gemfile because our application calls this directly and it will be removed from the ruby standard library eventually.