### PR TITLE
add version meta tag

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -17,4 +17,8 @@ S.register(:slack_url) do
   ENV["SLACK_URL"] || "https://hooks.slack.com/services/WHATEVERELSE"
 end
 
+S.register(:version) do
+  ENV["APP_VERSION"] || "APP_VERSION"
+end
+
 SemanticLogger.add_appender(io: S.log_stream, level: :info) unless ENV["APP_ENV"] == "test"

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -37,6 +37,7 @@
       description = Navigation::Description.for(request.path_info)
     %>
     <meta name="description" content="<%= description %>"/>
+    <meta name="version" content="<%=S.version%>">
 
     <meta name="theme-color" content="#ffcb05"/>
 
@@ -56,6 +57,7 @@
     <meta name="twitter:site" content="@umichlibrary">
     <meta name="twitter:image" content="https://account.lib.umich.edu/icon-512x512.png" />
     <meta name="twitter:image:alt" content="University of Michigan's Block M" />
+
   </head>
   <body>
     <!-- Google Tag Manager (noscript) -->


### PR DESCRIPTION
Adds version meta tag. This will expose the version of the site so you can verify which image is running without checking kubernetes or argocd.

This changes makes it so that the application exposes the value in the environment variable `APP_VERSION` through the `version` meta tag. In development this is always `APP_VERSION`. In kubernetes, this is inserted at kubernetes application time, and is the tag of the app image. The tag is either the release version (in production for `stable` images) or the commit hash (in not-production for `unstable` images). 

The development version doesn't try to calculate the version because it'd be somewhat complex logic relying on `git` cli commands, and it's not the right place for this logic in the first place. We want to insert the image information and that information comes from outside of the application. So, when viewing the site on localhost, the version will always show `APP_VERSION`, and it is supposed to do that. 
