### PR TITLE
Bug: Prevent dependabot automerge if failed workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,13 +1,18 @@
 name: Dependabot pull requests
 
 on:
+  workflow_run:
+    # Make sure `test.yml` successfully completes
+    workflows: ["Run Tests"]
+    types:
+      - completed
   pull_request:
 
 jobs:
   dependabot:
     name: Auto-merge Dependabot PRs
     runs-on: ubuntu-latest
-    if: ${{github.event.pull_request.user.login == 'dependabot[bot]'}}
+    if: ${{github.event.pull_request.user.login == 'dependabot[bot]' && github.event_name == 'pull_request'}}
     permissions:
       pull-requests: write
       contents: write
@@ -21,5 +26,6 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve the PR
         run: gh pr review --approve "$PR_URL"
-      - name: Merge the PR
-        run: gh pr merge --squash --auto "$PR_URL"
+      # Prevent merging for testing
+      # - name: Merge the PR
+      #   run: gh pr merge --squash --auto "$PR_URL"

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem "net-smtp", require: false
 
 gem "alma_rest_client",
   git: "https://github.com/mlibrary/alma_rest_client",
-  tag: "v2.0.0"
+  tag: "1.3.1"
 
 gem "yabeda-puma-plugin"
 gem "yabeda-prometheus"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,11 @@
 GIT
   remote: https://github.com/mlibrary/alma_rest_client
-  revision: 9606225d82480b6d1568902813ae9018dd8c1acc
-  tag: v2.0.0
+  revision: 2014809367ece3f21935bd24b45a12285f61e253
+  tag: 1.3.1
   specs:
-    alma_rest_client (2.0.0)
+    alma_rest_client (1.3.1)
       activesupport (~> 7.0, >= 4.2)
-      faraday
-      faraday-retry
-      httpx
+      httparty
       rexml
 
 GEM
@@ -47,22 +45,11 @@ GEM
     docile (1.4.1)
     drb (2.2.3)
     dry-initializer (3.2.0)
-    faraday (2.14.0)
-      faraday-net_http (>= 2.0, < 3.5)
-      json
-      logger
-    faraday-net_http (3.4.1)
-      net-http (>= 0.5.0)
-    faraday-retry (2.3.2)
-      faraday (~> 2.0)
     hashdiff (1.2.0)
-    http-2 (1.1.1)
     httparty (0.23.1)
       csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    httpx (1.6.2)
-      http-2 (>= 1.0.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     json (2.15.0)
@@ -79,8 +66,6 @@ GEM
       bigdecimal (~> 3.1)
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
-    net-http (0.6.0)
-      uri
     net-protocol (0.2.2)
       timeout
     net-smtp (0.5.1)
@@ -198,7 +183,6 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
-    uri (1.0.3)
     webmock (3.25.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)


### PR DESCRIPTION
# Overview
The current `dependabot.yml` workflow still merges the pull requests, even when tests don't pass. This pull request ads the check to make sure `test.yml` completes before continuing.
