### PR TITLE
ci: change dependabot to use interval monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,9 @@ version: 2
 multi-ecosystem-groups:
   app-dependencies:
     schedule:
-      interval: "cron"
-      cronjob: "0 6 1-7 * 1" # Every first Monday of the month at 6:00am
+      interval: "monthly"
+      time: "06:00"
+      day: "monday"
       timezone: "America/Detroit"
     commit-message:
       prefix: "Monthly dependency updates: "


### PR DESCRIPTION
Changing dependabot to use interval monthly instead of cron.