### PR TITLE
Fully update to ruby 3.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,10 +30,10 @@ jobs:
         run: cat env.* > .env
       - name: Load .env file
         uses: xom9ikk/dotenv@v2.3.0
-      - name: Set up Ruby 3.3
+      - name: Set up Ruby 3.4
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: '3.4'
           bundler-cache: true
       - name: Run linter for Ruby
         run: bundle exec standardrb

--- a/Gemfile
+++ b/Gemfile
@@ -28,8 +28,7 @@ gem "yabeda-prometheus"
 
 group :development, :test do
   gem "standard"
-  gem "pry"
-  gem "pry-byebug"
+  gem "debug"
   gem "rack-test"
   gem "rspec"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,20 +31,23 @@ GEM
     base64 (0.3.0)
     benchmark (0.4.1)
     bigdecimal (3.2.3)
-    byebug (12.0.0)
     canister (0.9.2)
     climate_control (1.2.0)
-    coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
     crack (1.0.0)
       bigdecimal
       rexml
     csv (3.3.5)
+    date (3.4.1)
+    debug (1.11.0)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     diff-lcs (1.6.2)
     docile (1.4.1)
     drb (2.2.3)
     dry-initializer (3.2.0)
+    erb (5.0.2)
     hashdiff (1.2.0)
     httparty (0.23.1)
       csv
@@ -52,13 +55,17 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    io-console (0.8.1)
+    irb (1.15.2)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.15.0)
     jwt (3.1.2)
       base64
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
-    method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.5)
     multi_json (1.17.0)
@@ -76,15 +83,15 @@ GEM
     parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
+    pp (0.6.3)
+      prettyprint
+    prettyprint (0.2.0)
     prism (1.5.1)
     prometheus-client (4.2.5)
       base64
-    pry (0.15.2)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-byebug (3.11.0)
-      byebug (~> 12.0)
-      pry (>= 0.13, < 0.16)
+    psych (5.2.6)
+      date
+      stringio
     public_suffix (6.0.2)
     puma (7.0.4)
       nio4r (~> 2.0)
@@ -102,8 +109,14 @@ GEM
     rackup (2.2.1)
       rack (>= 3)
     rainbow (3.1.1)
+    rdoc (6.15.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
     redcarpet (3.6.1)
     regexp_parser (2.11.3)
+    reline (0.6.2)
+      io-console (~> 0.5)
     rexml (3.4.4)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
@@ -175,9 +188,11 @@ GEM
     standard-performance (1.8.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.25.0)
+    stringio (3.1.7)
     telephone_number (1.4.23)
     tilt (2.6.1)
     timeout (0.4.3)
+    tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
@@ -210,12 +225,11 @@ DEPENDENCIES
   canister
   climate_control
   csv
+  debug
   httparty
   jwt
   net-smtp
   ostruct
-  pry
-  pry-byebug
   puma
   rack-test
   rackup

--- a/account.rb
+++ b/account.rb
@@ -8,7 +8,7 @@ require "ostruct"
 require "active_support"
 require "active_support/core_ext/numeric"
 
-require "byebug" if development?
+require "debug" if development?
 
 require_relative "lib/services"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@
 
 require "rack/test"
 require "rspec"
-require "pry-byebug"
+require "debug"
 require "webmock/rspec"
 require "simplecov"
 require "climate_control"


### PR DESCRIPTION
`byebug` was causing warnings in test, so it has been replaced with `debug`.

Also updating gha for tests to use ruby 3.4