### PR TITLE
Dockerfile and compose.ymp update yearly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,13 @@ multi-ecosystem-groups:
     commit-message:
       prefix: "Monthly dependency updates: "
 
+  container-updates:
+    schedule:
+      interval: "cron"
+      cronjob: "0 6 3 4 *" #April 3 at 6AM
+      timezone: "America/Detroit"
+    commit-message:
+      prefix: "Annual container update: "
 
 updates:
   # For npm/JavaScript dependencies

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -25,9 +25,8 @@ jobs:
     steps:
       - name: Fetch Dependabot Metadata
         uses: dependabot/fetch-metadata@v2
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Approve the PR
-        run: gh pr review --approve "$PR_URL"
-      - name: Merge the PR
-        run: gh pr merge --squash --auto "$PR_URL"
+      - name: Approve and Merge the PR
+        if: ${{ steps.dependabot-metadata.outputs.dependency-group == 'app-dependencies' }}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --squash --auto "$PR_URL"


### PR DESCRIPTION
Adds second dependency group for Dockerfile and docker-compose because we only want to update those yearly. We also don't want those to auto-merge because tests will not automatically catch changes due to the image change because the tests GHA won't get an automated ruby version update.