### PR TITLE
dependabot.yml looks for prs again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,11 +40,11 @@ updates:
   # For Docker
   - package-ecosystem: "docker"
     directory: "/"
-    multi-ecosystem-group: "app-dependencies"
+    multi-ecosystem-group: "container-updates"
     patterns: ["*"]
 
   # For Docker Compose
   - package-ecosystem: "docker-compose"
     directory: "/"
-    multi-ecosystem-group: "app-dependencies"
+    multi-ecosystem-group: "container-updates"
     patterns: ["*"]

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,21 +1,12 @@
 name: Dependabot pull requests
 
-on:
-  workflow_run:
-    workflows: ["Run Tests"]
-    types:
-      - completed
+on: pull_request
 
 jobs:
   dependabot:
     name: Auto-merge Dependabot PRs
     runs-on: ubuntu-latest
-    # Only trigger if tests have passed on a Dependabot-created PR
-    if: |
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.pull_requests != '' &&
-      startsWith(github.event.workflow_run.head_branch, 'dependabot/') &&
-      github.event.workflow_run.pull_requests[0].user.login == 'dependabot[bot]'
+    if:  ${{github.event.pull_request.user.login == 'dependabot[bot]'}}
     permissions:
       pull-requests: write
       contents: write
@@ -27,7 +18,8 @@ jobs:
         uses: dependabot/fetch-metadata@v2
         id: dependabot-metadata
       - name: Approve and Merge the PR
-        if: ${{ steps.dependabot-metadata.outputs.dependency-group == 'app-dependencies' }}
+        # Don't do this for the container-updates group
+        if: ${{ steps.dependabot-metadata.outputs.dependency-group != 'container-updates' }}
         run: |
           gh pr review --approve "$PR_URL"
           gh pr merge --squash --auto "$PR_URL"


### PR DESCRIPTION
There were some mistakes in the dependabot configs. This (hopefuly) fixes them.  

Branch protection has the tests must pass part. 