### PR TITLE
change to node 24; change apt-get to apt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM ruby:3.4 AS development
 ARG UNAME=app
 ARG UID=1000
 ARG GID=1000
-ARG NODE_MAJOR=20
+ARG NODE_MAJOR=24
 
 
-RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
+RUN apt update -yqq && apt install -yqq --no-install-recommends \
   ca-certificates \
   gnupg \
   apt-transport-https \
@@ -15,7 +15,7 @@ RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
-RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends nodejs
+RUN apt update -yqq && apt-get install -yqq --no-install-recommends nodejs
 
 RUN gem install bundler
 RUN npm install -g npm


### PR DESCRIPTION
uses `apt` instead of `apt-get` because it's newer.

Updated to node 24 to get it to build properly. 